### PR TITLE
fix #111: avoiding thread unsafe access to StringBuilderWriter

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/loggingjson/JsonFormatter.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/JsonFormatter.java
@@ -6,10 +6,10 @@ import org.jboss.logmanager.ExtFormatter;
 import org.jboss.logmanager.ExtLogRecord;
 
 public class JsonFormatter extends ExtFormatter {
-    private final StringBuilderWriter writer = new StringBuilderWriter();
+
     private final List<JsonProvider> providers;
     private final JsonFactory jsonFactory;
-    private String recordDelimiter;
+    private final String recordDelimiter;
 
     public JsonFormatter(List<JsonProvider> providers, JsonFactory jsonFactory, Config config) {
         this.providers = providers;
@@ -19,25 +19,21 @@ public class JsonFormatter extends ExtFormatter {
 
     @Override
     public String format(ExtLogRecord record) {
-        try {
-            try (JsonGenerator generator = this.jsonFactory.createGenerator(writer)) {
-                generator.writeStartObject();
-                for (JsonProvider provider : this.providers) {
-                    provider.writeTo(generator, record);
-                }
-                generator.writeEndObject();
-                generator.flush();
-                if (recordDelimiter != null) {
-                    writer.write(recordDelimiter);
-                }
+        final StringBuilderWriter writer = new StringBuilderWriter();
+        try (JsonGenerator generator = this.jsonFactory.createGenerator(writer)) {
+            generator.writeStartObject();
+            for (JsonProvider provider : this.providers) {
+                provider.writeTo(generator, record);
+            }
+            generator.writeEndObject();
+            generator.flush();
+            if (recordDelimiter != null) {
+                writer.write(recordDelimiter);
             }
             return writer.toString();
         } catch (Exception e) {
             // Wrap and rethrow
             throw new RuntimeException(e);
-        } finally {
-            // Clear the writer for the next format
-            writer.clear();
         }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/StringBuilderWriter.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/StringBuilderWriter.java
@@ -7,20 +7,7 @@ final public class StringBuilderWriter extends Writer {
     private final StringBuilder builder;
 
     public StringBuilderWriter() {
-        this(new StringBuilder());
-    }
-
-    public StringBuilderWriter(final StringBuilder builder) {
-        this.builder = builder;
-    }
-
-    /**
-     * Clears the builder used for the writer.
-     *
-     * @see StringBuilder#setLength(int)
-     */
-    void clear() {
-        builder.setLength(0);
+        builder = new StringBuilder();
     }
 
     @Override


### PR DESCRIPTION
not sure if there is any guarantee that formatting will happen always on a single thread. According to my local tests, it is possible to have multiple threads calling `write`/`append` or `clear` on the same instance of `StringBuilderWriter`. 

