### PR TITLE
Changed JsonFormatter to use fresh StringBuilderWriter for every format

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/loggingjson/JsonFormatter.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/JsonFormatter.java
@@ -6,10 +6,9 @@ import org.jboss.logmanager.ExtFormatter;
 import org.jboss.logmanager.ExtLogRecord;
 
 public class JsonFormatter extends ExtFormatter {
-    private final StringBuilderWriter writer = new StringBuilderWriter();
     private final List<JsonProvider> providers;
     private final JsonFactory jsonFactory;
-    private String recordDelimiter;
+    private final String recordDelimiter;
 
     public JsonFormatter(List<JsonProvider> providers, JsonFactory jsonFactory, Config config) {
         this.providers = providers;
@@ -20,6 +19,7 @@ public class JsonFormatter extends ExtFormatter {
     @Override
     public String format(ExtLogRecord record) {
         try {
+            final StringBuilderWriter writer = new StringBuilderWriter();
             try (JsonGenerator generator = this.jsonFactory.createGenerator(writer)) {
                 generator.writeStartObject();
                 for (JsonProvider provider : this.providers) {
@@ -35,9 +35,6 @@ public class JsonFormatter extends ExtFormatter {
         } catch (Exception e) {
             // Wrap and rethrow
             throw new RuntimeException(e);
-        } finally {
-            // Clear the writer for the next format
-            writer.clear();
         }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/StringBuilderWriter.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/StringBuilderWriter.java
@@ -7,20 +7,7 @@ final public class StringBuilderWriter extends Writer {
     private final StringBuilder builder;
 
     public StringBuilderWriter() {
-        this(new StringBuilder());
-    }
-
-    public StringBuilderWriter(final StringBuilder builder) {
-        this.builder = builder;
-    }
-
-    /**
-     * Clears the builder used for the writer.
-     *
-     * @see StringBuilder#setLength(int)
-     */
-    void clear() {
-        builder.setLength(0);
+        this.builder = new StringBuilder(500);
     }
 
     @Override


### PR DESCRIPTION
Changed JsonFormatter to use fresh StringBuilderWriter for every format(), to fix when called from multiple threads.

Fixes #111 