### PR TITLE
update for quarkus 3.0.0 (javax/jakarta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to add your own custom way to handle the LogRecords.
 You can create your own implementations of `io.quarkiverse.loggingjson.JsonProvider`, and provide it using CDI.
 Example implementation:
 ```java
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import java.io.IOException;
 
 import io.quarkiverse.loggingjson.JsonProvider;

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.loggingjson</groupId>
         <artifactId>quarkus-logging-json-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>io.quarkiverse.loggingjson</groupId>
             <artifactId>quarkus-logging-json</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/providers/custom/CustomJsonProviderJsonbTest.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/providers/custom/CustomJsonProviderJsonbTest.java
@@ -2,7 +2,7 @@ package io.quarkiverse.loggingjson.deployment.providers.custom;
 
 import java.util.Collections;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/providers/custom/FirstCustomJsonProvider.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/providers/custom/FirstCustomJsonProvider.java
@@ -2,7 +2,7 @@ package io.quarkiverse.loggingjson.deployment.providers.custom;
 
 import java.io.IOException;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import org.jboss.logmanager.ExtLogRecord;
 

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/providers/custom/SecondCustomJsonProvider.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/providers/custom/SecondCustomJsonProvider.java
@@ -2,7 +2,7 @@ package io.quarkiverse.loggingjson.deployment.providers.custom;
 
 import java.io.IOException;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 import org.jboss.logmanager.ExtLogRecord;
 

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/providers/custom/ThirdCustomJsonProvider.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/providers/custom/ThirdCustomJsonProvider.java
@@ -2,7 +2,7 @@ package io.quarkiverse.loggingjson.deployment.providers.custom;
 
 import java.io.IOException;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 import org.jboss.logmanager.ExtLogRecord;
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.loggingjson</groupId>
         <artifactId>quarkus-logging-json-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.loggingjson</groupId>
         <artifactId>quarkus-logging-json-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/src/main/java/io/quarkiverse/loggingjson/it/CustomJsonProvider.java
+++ b/integration-tests/src/main/java/io/quarkiverse/loggingjson/it/CustomJsonProvider.java
@@ -2,7 +2,7 @@ package io.quarkiverse.loggingjson.it;
 
 import java.io.IOException;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 import org.jboss.logmanager.ExtLogRecord;
 

--- a/integration-tests/src/main/java/io/quarkiverse/loggingjson/it/GreetingResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/loggingjson/it/GreetingResource.java
@@ -2,10 +2,10 @@ package io.quarkiverse.loggingjson.it;
 
 import java.util.logging.Logger;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/hello")
 public class GreetingResource {

--- a/integration-tests/src/test/java/io/quarkiverse/loggingjson/it/NativeGreetingResourceIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/loggingjson/it/NativeGreetingResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkiverse.loggingjson.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeGreetingResourceIT extends GreetingResourceTest {
 
     // Execute the same tests but in native mode.

--- a/pom.xml
+++ b/pom.xml
@@ -10,17 +10,16 @@
     <groupId>io.quarkiverse.loggingjson</groupId>
     <artifactId>quarkus-logging-json-parent</artifactId>
     <name>Quarkus Logging JSON - Parent</name>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-        <quarkus.version>2.13.0.Final</quarkus.version>
+        <quarkus.version>3.0.0.CR1</quarkus.version>
         <jacoco.version>0.8.8</jacoco.version>
         <!-- Sonar properties -->
         <sonar.projectKey>quarkiverse_quarkus-logging-json</sonar.projectKey>
@@ -78,7 +77,9 @@
                 <configuration>
                     <excludedGroups>integration</excludedGroups>
                     <systemPropertyVariables>
+<!--
                         <jacoco-agent.destfile>${project.build.directory}/jacoco-ut.exec</jacoco-agent.destfile>
+-->                   
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
                     </systemPropertyVariables>
@@ -93,13 +94,16 @@
                         <configuration>
                             <excludedGroups>!integration</excludedGroups>
                             <groups>integration</groups>
+<!--
                             <systemPropertyVariables>
                                 <jacoco-agent.destfile>${project.build.directory}/jacoco-it.exec</jacoco-agent.destfile>
                             </systemPropertyVariables>
+-->                            
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+<!--            
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -183,6 +187,7 @@
                     </execution>
                 </executions>
             </plugin>
+-->            
         </plugins>
     </build>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.loggingjson</groupId>
         <artifactId>quarkus-logging-json-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/jsonb/JsonbJsonFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/jsonb/JsonbJsonFactory.java
@@ -2,8 +2,8 @@ package io.quarkiverse.loggingjson.jsonb;
 
 import java.util.HashMap;
 
-import javax.json.Json;
-import javax.json.stream.JsonGeneratorFactory;
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGeneratorFactory;
 
 import org.eclipse.yasson.YassonJsonb;
 import org.eclipse.yasson.internal.JsonBindingBuilder;

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/jsonb/JsonbJsonGenerator.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/jsonb/JsonbJsonGenerator.java
@@ -5,18 +5,18 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 
-import javax.json.JsonStructure;
-import javax.json.JsonValue;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
 
 import org.eclipse.yasson.YassonJsonb;
 
 import io.quarkiverse.loggingjson.JsonGenerator;
 
 public class JsonbJsonGenerator implements JsonGenerator {
-    private final javax.json.stream.JsonGenerator generator;
+    private final jakarta.json.stream.JsonGenerator generator;
     private final YassonJsonb jsonb;
 
-    public JsonbJsonGenerator(javax.json.stream.JsonGenerator generator, YassonJsonb jsonb) {
+    public JsonbJsonGenerator(jakarta.json.stream.JsonGenerator generator, YassonJsonb jsonb) {
         this.generator = generator;
         this.jsonb = jsonb;
     }


### PR DESCRIPTION
Because I needed a local build that works with Quarkus 3.0.0.CR1 even for native image builds, I did a fork and quick fix of he quarkiverse/quarkus-logging-json extension. I needed the io.quarkiverse.loggingjson.providers.KeyValueStructuredArgument.kv. 
Please note the disabled jacoco in the pom.xml because I struggled getting it working here.
Maybe you can consider to integrate these changes.