### PR TITLE
refactor: equals avoids null

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/TimestampJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/TimestampJsonProvider.java
@@ -34,7 +34,7 @@ public class TimestampJsonProvider implements JsonProvider, Enabled {
             zoneId = ZoneId.of(config.zoneId);
         }
 
-        if (config.dateFormat != null && !config.dateFormat.equals("default")) {
+        if (config.dateFormat != null && !"default".equals(config.dateFormat)) {
             dateTimeFormatter = DateTimeFormatter.ofPattern(config.dateFormat).withZone(zoneId);
         } else {
             dateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId);


### PR DESCRIPTION
Happy Hacktoberfest!

This refactor checks that any combination of String literals is on the left side of an equals() comparison to prevent null pointer exceptions.