### PR TITLE
Make quarkus-jsonb and quarkus-jackson optionals

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -18,13 +18,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson-deployment</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jsonb-deployment</artifactId>
-            <scope>compile</scope>
+            <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.loggingjson</groupId>
@@ -42,6 +36,17 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/deployment/src/main/java/io/quarkiverse/loggingjson/deployment/LoggingJsonProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingjson/deployment/LoggingJsonProcessor.java
@@ -4,8 +4,11 @@ import java.util.Collection;
 
 import org.jboss.jandex.ClassInfo;
 
+import io.quarkiverse.loggingjson.JsonFactory;
 import io.quarkiverse.loggingjson.LoggingJsonRecorder;
 import io.quarkiverse.loggingjson.config.Config;
+import io.quarkiverse.loggingjson.jackson.JacksonJsonFactory;
+import io.quarkiverse.loggingjson.jsonb.JsonbJsonFactory;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
@@ -31,21 +34,21 @@ class LoggingJsonProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     LogConsoleFormatBuildItem setUpConsoleFormatter(Capabilities capabilities, LoggingJsonRecorder recorder,
             Config config) {
-        return new LogConsoleFormatBuildItem(recorder.initializeConsoleJsonLogging(config, useJackson(capabilities)));
+        return new LogConsoleFormatBuildItem(recorder.initializeConsoleJsonLogging(config, jsonFactory(capabilities)));
     }
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     LogFileFormatBuildItem setUpFileFormatter(Capabilities capabilities, LoggingJsonRecorder recorder,
             Config config) {
-        return new LogFileFormatBuildItem(recorder.initializeFileJsonLogging(config, useJackson(capabilities)));
+        return new LogFileFormatBuildItem(recorder.initializeFileJsonLogging(config, jsonFactory(capabilities)));
     }
 
-    private boolean useJackson(Capabilities capabilities) {
+    private JsonFactory jsonFactory(Capabilities capabilities) {
         if (capabilities.isPresent(Capability.JACKSON)) {
-            return true;
+            return new JacksonJsonFactory();
         } else if (capabilities.isPresent(Capability.JSONB)) {
-            return false;
+            return new JsonbJsonFactory();
         } else {
             throw new RuntimeException(
                     "Missing json implementation to use for logging-json. Supported: [quarkus-jackson, quarkus-jsonb]");

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDefaultFormatterJacksonTest.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDefaultFormatterJacksonTest.java
@@ -16,7 +16,7 @@ class JsonDefaultFormatterJacksonTest extends JsonDefaultFormatterBaseTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
             .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-jackson-deployment", System.getProperty("test.quarkus.version"))))
+                    new AppArtifact("io.quarkus", "quarkus-jackson", System.getProperty("test.quarkus.version"))))
             .withConfigurationResource("application-json.properties");
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDefaultFormatterJsonbTest.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDefaultFormatterJsonbTest.java
@@ -16,7 +16,7 @@ class JsonDefaultFormatterJsonbTest extends JsonDefaultFormatterBaseTest {
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
             .setForcedDependencies(Collections.singletonList(
-                    new AppArtifact("io.quarkus", "quarkus-jsonb-deployment", System.getProperty("test.quarkus.version"))))
+                    new AppArtifact("io.quarkus", "quarkus-jsonb", System.getProperty("test.quarkus.version"))))
             .withConfigurationResource("application-json.properties");
 
     @Test

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -15,8 +15,9 @@
         <!-- Make sure the doc is built after the other artifacts -->
         <dependency>
             <groupId>io.quarkiverse.loggingjson</groupId>
-            <artifactId>quarkus-logging-json-deployment</artifactId>
+            <artifactId>quarkus-logging-json-integration-tests</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -18,13 +18,17 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
-            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jsonb</artifactId>
-            <scope>compile</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
@@ -11,8 +11,6 @@ import org.slf4j.LoggerFactory;
 
 import io.quarkiverse.loggingjson.config.Config;
 import io.quarkiverse.loggingjson.config.ConfigFormatter;
-import io.quarkiverse.loggingjson.jackson.JacksonJsonFactory;
-import io.quarkiverse.loggingjson.jsonb.JsonbJsonFactory;
 import io.quarkiverse.loggingjson.providers.*;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableInstance;
@@ -24,17 +22,17 @@ public class LoggingJsonRecorder {
     private static final Logger log = LoggerFactory.getLogger(LoggingJsonRecorder.class);
 
     public RuntimeValue<Optional<Formatter>> initializeConsoleJsonLogging(Config config,
-            boolean useJackson) {
-        return initializeJsonLogging(config.console, config, useJackson);
+            JsonFactory jsonFactory) {
+        return initializeJsonLogging(config.console, config, jsonFactory);
     }
 
     public RuntimeValue<Optional<Formatter>> initializeFileJsonLogging(Config config,
-            boolean useJackson) {
-        return initializeJsonLogging(config.file, config, useJackson);
+            JsonFactory jsonFactory) {
+        return initializeJsonLogging(config.file, config, jsonFactory);
     }
 
     public RuntimeValue<Optional<Formatter>> initializeJsonLogging(ConfigFormatter formatter, Config config,
-            boolean useJackson) {
+            JsonFactory jsonFactory) {
         if (formatter == null || !formatter.isEnabled()) {
             return new RuntimeValue<>(Optional.empty());
         }
@@ -62,15 +60,6 @@ public class LoggingJsonRecorder {
             String installedProviders = providers.stream().map(p -> p.getClass().toString())
                     .collect(Collectors.joining(", ", "[", "]"));
             log.debug("Installed json providers {}", installedProviders);
-        }
-
-        JsonFactory jsonFactory;
-        if (useJackson) {
-            log.debug("Using Jackson as the json implementation");
-            jsonFactory = new JacksonJsonFactory();
-        } else {
-            log.debug("Using Jsonb as the json implementation");
-            jsonFactory = new JsonbJsonFactory();
         }
 
         return new RuntimeValue<>(Optional.of(new JsonFormatter(providers, jsonFactory, config)));


### PR DESCRIPTION
Currently, both quarkus-jackson and quarkus-jsonb are added to the application classpath by the extension. AFAIK, this is not the expected behavior and it seems like a huge issue to me ! The extension should let the final application provides them and detect the available capabilities (jackson or jsonb).

This PR fixes this behavior, quarkus-jackson and quarkus-jsonb are now optionals and will not added to the classpath automatically.