### PR TITLE
Allow higher resolution of timestamps

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/TimestampJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/TimestampJsonProvider.java
@@ -44,8 +44,8 @@ public class TimestampJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
-        long millis = event.getMillis();
-        JsonWritingUtils.writeStringField(generator, fieldName, dateTimeFormatter.format(Instant.ofEpochMilli(millis)));
+        Instant timestamp = event.getInstant();
+        JsonWritingUtils.writeStringField(generator, fieldName, dateTimeFormatter.format(timestamp));
     }
 
     @Override

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/TimestampJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/TimestampJsonProviderJsonbTest.java
@@ -8,6 +8,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.zone.ZoneRulesException;
 import java.util.Optional;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.jboss.logmanager.ExtLogRecord;
 import org.junit.jupiter.api.Assertions;
@@ -37,6 +39,10 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
         String timestamp = result.findValue("timestamp").asText();
         Assertions.assertNotNull(timestamp);
+
+        Matcher nanosMatcher = Pattern.compile("(.*)\\.(?<nanos>[0-9]{9})(Z|\\+.*)").matcher(timestamp);
+        Assertions.assertTrue(nanosMatcher.matches());
+
         OffsetDateTime logTimestamp = OffsetDateTime.parse(timestamp);
         Assertions.assertTrue(beforeLog.isBefore(logTimestamp) || beforeLog.isEqual(logTimestamp));
         Assertions.assertTrue(afterLog.isAfter(logTimestamp) || afterLog.isEqual(logTimestamp));


### PR DESCRIPTION
As discussed in https://github.com/dmlloyd/jboss-logmanager-embedded/issues/7, I wanted to allow nano precision for the timestamp in this extension too.