### PR TITLE
Support "source" fields from LogRecord

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDefaultFormatterSourceFieldsJacksonTest.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDefaultFormatterSourceFieldsJacksonTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.loggingjson.deployment;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.test.QuarkusUnitTest;
+
+class JsonDefaultFormatterSourceFieldsJacksonTest extends JsonDefaultFormatterBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .setForcedDependencies(Collections.singletonList(
+                    new AppArtifact("io.quarkus", "quarkus-jackson", System.getProperty("test.quarkus.version"))))
+            .withConfigurationResource("application-json-source-fields.properties");
+
+    @Test
+    void testFormatterUsingJackson() throws Exception {
+        testLogOutputWithSourceFields();
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDefaultFormatterSourceFieldsJsonbTest.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDefaultFormatterSourceFieldsJsonbTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.loggingjson.deployment;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.test.QuarkusUnitTest;
+
+class JsonDefaultFormatterSourceFieldsJsonbTest extends JsonDefaultFormatterBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .setForcedDependencies(Collections.singletonList(
+                    new AppArtifact("io.quarkus", "quarkus-jsonb", System.getProperty("test.quarkus.version"))))
+            .withConfigurationResource("application-json-source-fields.properties");
+
+    @Test
+    void testFormatterUsingJsonb() throws Exception {
+        testLogOutputWithSourceFields();
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonECSFormatterSourceFieldsJacksonTest.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonECSFormatterSourceFieldsJacksonTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.loggingjson.deployment;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.test.QuarkusUnitTest;
+
+class JsonECSFormatterSourceFieldsJacksonTest extends JsonECSFormatterBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .setForcedDependencies(Collections.singletonList(
+                    new AppArtifact("io.quarkus", "quarkus-jackson-deployment", System.getProperty("test.quarkus.version"))))
+            .withConfigurationResource("application-json-source-fields-ecs.properties");
+
+    @Test
+    void testFormatterUsingJackson() throws Exception {
+        testLogOutputWithSourceFields();
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonECSFormatterSourceFieldsJsonbTest.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonECSFormatterSourceFieldsJsonbTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.loggingjson.deployment;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.test.QuarkusUnitTest;
+
+class JsonECSFormatterSourceFieldsJsonbTest extends JsonECSFormatterBaseTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .setForcedDependencies(Collections.singletonList(
+                    new AppArtifact("io.quarkus", "quarkus-jsonb-deployment", System.getProperty("test.quarkus.version"))))
+            .withConfigurationResource("application-json-source-fields-ecs.properties");
+
+    @Test
+    void testFormatterUsingJsonb() throws Exception {
+        testLogOutputWithSourceFields();
+    }
+}

--- a/deployment/src/test/resources/application-json-source-fields-ecs.properties
+++ b/deployment/src/test/resources/application-json-source-fields-ecs.properties
@@ -1,0 +1,12 @@
+quarkus.log.level=INFO
+quarkus.log.console.enable=true
+quarkus.log.console.level=WARNING
+quarkus.log.json.console.enable=true
+quarkus.log.json.log-format=ecs
+quarkus.log.json.fields.arguments.include-non-structured-arguments=true
+quarkus.log.json.additional-field."service.name".value=deployment-test
+
+# these fields are disabled by default
+quarkus.log.json.fields.source-method-name.enabled=true
+quarkus.log.json.fields.source-file-name.enabled=true
+quarkus.log.json.fields.source-line-number.enabled=true

--- a/deployment/src/test/resources/application-json-source-fields.properties
+++ b/deployment/src/test/resources/application-json-source-fields.properties
@@ -1,0 +1,13 @@
+quarkus.log.level=INFO
+quarkus.log.console.enable=true
+quarkus.log.console.level=WARNING
+quarkus.log.json.console.enable=true
+quarkus.log.json.fields.arguments.include-non-structured-arguments=true
+quarkus.log.json.additional-field.serviceName.value=deployment-test
+quarkus.log.json.file.enable=true
+
+# these fields are disabled by default
+quarkus.log.json.fields.source-class-name.enabled=true
+quarkus.log.json.fields.source-method-name.enabled=true
+quarkus.log.json.fields.source-file-name.enabled=true
+quarkus.log.json.fields.source-line-number.enabled=true

--- a/docs/modules/ROOT/pages/includes/quarkus-log-json.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-log-json.adoc
@@ -666,6 +666,134 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a| [[quarkus-log-json_quarkus.log.json.fields.source-class-name.field-name]]`link:#quarkus-log-json_quarkus.log.json.fields.source-class-name.field-name[quarkus.log.json.fields.source-class-name.field-name]`
+
+[.description]
+--
+Used to change the json key for the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_SOURCE_CLASS_NAME_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_SOURCE_CLASS_NAME_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|
+
+
+a| [[quarkus-log-json_quarkus.log.json.fields.source-class-name.enabled]]`link:#quarkus-log-json_quarkus.log.json.fields.source-class-name.enabled[quarkus.log.json.fields.source-class-name.enabled]`
+
+[.description]
+--
+Enable or disable the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_SOURCE_CLASS_NAME_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_SOURCE_CLASS_NAME_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`false`
+
+
+a| [[quarkus-log-json_quarkus.log.json.fields.source-method-name.field-name]]`link:#quarkus-log-json_quarkus.log.json.fields.source-method-name.field-name[quarkus.log.json.fields.source-method-name.field-name]`
+
+[.description]
+--
+Used to change the json key for the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_SOURCE_METHOD_NAME_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_SOURCE_METHOD_NAME_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|
+
+
+a| [[quarkus-log-json_quarkus.log.json.fields.source-method-name.enabled]]`link:#quarkus-log-json_quarkus.log.json.fields.source-method-name.enabled[quarkus.log.json.fields.source-method-name.enabled]`
+
+[.description]
+--
+Enable or disable the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_SOURCE_METHOD_NAME_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_SOURCE_METHOD_NAME_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`false`
+
+
+a| [[quarkus-log-json_quarkus.log.json.fields.source-file-name.field-name]]`link:#quarkus-log-json_quarkus.log.json.fields.source-file-name.field-name[quarkus.log.json.fields.source-file-name.field-name]`
+
+[.description]
+--
+Used to change the json key for the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_SOURCE_FILE_NAME_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_SOURCE_FILE_NAME_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|
+
+
+a| [[quarkus-log-json_quarkus.log.json.fields.source-file-name.enabled]]`link:#quarkus-log-json_quarkus.log.json.fields.source-file-name.enabled[quarkus.log.json.fields.source-file-name.enabled]`
+
+[.description]
+--
+Enable or disable the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_SOURCE_FILE_NAME_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_SOURCE_FILE_NAME_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`false`
+
+
+a| [[quarkus-log-json_quarkus.log.json.fields.source-line-number.field-name]]`link:#quarkus-log-json_quarkus.log.json.fields.source-line-number.field-name[quarkus.log.json.fields.source-line-number.field-name]`
+
+[.description]
+--
+Used to change the json key for the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_SOURCE_LINE_NUMBER_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_SOURCE_LINE_NUMBER_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|
+
+
+a| [[quarkus-log-json_quarkus.log.json.fields.source-line-number.enabled]]`link:#quarkus-log-json_quarkus.log.json.fields.source-line-number.enabled[quarkus.log.json.fields.source-line-number.enabled]`
+
+[.description]
+--
+Enable or disable the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_SOURCE_LINE_NUMBER_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_SOURCE_LINE_NUMBER_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`false`
+
+
 a| [[quarkus-log-json_quarkus.log.json.pretty-print]]`link:#quarkus-log-json_quarkus.log.json.pretty-print[quarkus.log.json.pretty-print]`
 
 [.description]

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
@@ -84,6 +84,10 @@ public class LoggingJsonRecorder {
         providers.add(new StackTraceJsonProvider(config.fields.stackTrace));
         providers.add(new ErrorTypeJsonProvider(config.fields.errorType));
         providers.add(new ErrorMessageJsonProvider(config.fields.errorMessage));
+        providers.add(new SourceClassNameJsonProvider(config.fields.sourceClassName));
+        providers.add(new SourceMethodNameJsonProvider(config.fields.sourceMethodName));
+        providers.add(new SourceFileNameJsonProvider(config.fields.sourceFileName));
+        providers.add(new SourceLineNumberJsonProvider(config.fields.sourceLineNumber));
         providers.add(new ArgumentsJsonProvider(config.fields.arguments));
         providers.add(new AdditionalFieldsJsonProvider(config.additionalField));
         return providers;
@@ -94,6 +98,9 @@ public class LoggingJsonRecorder {
         providers.add(new TimestampJsonProvider(config.fields.timestamp, "@timestamp"));
         providers.add(new LoggerNameJsonProvider(config.fields.loggerName, "log.logger"));
         providers.add(new LogLevelJsonProvider(config.fields.level, "log.level"));
+        providers.add(new SourceFileNameJsonProvider(config.fields.sourceFileName, "log.origin.file.name"));
+        providers.add(new SourceLineNumberJsonProvider(config.fields.sourceLineNumber, "log.origin.file.line"));
+        providers.add(new SourceMethodNameJsonProvider(config.fields.sourceMethodName, "log.origin.function"));
         providers.add(new ThreadNameJsonProvider(config.fields.threadName, "process.thread.name"));
         providers.add(new ThreadIdJsonProvider(config.fields.threadId, "process.thread.id"));
         providers.add(new MDCJsonProvider(config.fields.mdc));

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/Config.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/Config.java
@@ -137,6 +137,26 @@ public class Config {
          */
         @ConfigItem
         public FieldConfig errorMessage;
+        /**
+         * Options for sourceClassName.
+         */
+        @ConfigItem
+        public FieldConfig sourceClassName;
+        /**
+         * Options for sourceMethodName.
+         */
+        @ConfigItem
+        public FieldConfig sourceMethodName;
+        /**
+         * Options for sourceFileName.
+         */
+        @ConfigItem
+        public FieldConfig sourceFileName;
+        /**
+         * Options for sourceLineNumber.
+         */
+        @ConfigItem
+        public FieldConfig sourceLineNumber;
     }
 
     @ConfigGroup

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SourceClassNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SourceClassNameJsonProvider.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.io.IOException;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+import io.quarkiverse.loggingjson.Enabled;
+import io.quarkiverse.loggingjson.JsonGenerator;
+import io.quarkiverse.loggingjson.JsonProvider;
+import io.quarkiverse.loggingjson.JsonWritingUtils;
+import io.quarkiverse.loggingjson.config.Config;
+
+public class SourceClassNameJsonProvider implements JsonProvider, Enabled {
+
+    private final String fieldName;
+    private final Config.FieldConfig config;
+
+    public SourceClassNameJsonProvider(Config.FieldConfig config) {
+        this(config, "sourceClassName");
+    }
+
+    public SourceClassNameJsonProvider(Config.FieldConfig config, String defaultName) {
+        this.config = config;
+        this.fieldName = config.fieldName.orElse(defaultName);
+    }
+
+    @Override
+    public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
+        JsonWritingUtils.writeStringField(generator, fieldName, event.getSourceClassName());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return config.enabled.orElse(false);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SourceFileNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SourceFileNameJsonProvider.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.io.IOException;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+import io.quarkiverse.loggingjson.Enabled;
+import io.quarkiverse.loggingjson.JsonGenerator;
+import io.quarkiverse.loggingjson.JsonProvider;
+import io.quarkiverse.loggingjson.JsonWritingUtils;
+import io.quarkiverse.loggingjson.config.Config;
+
+public class SourceFileNameJsonProvider implements JsonProvider, Enabled {
+
+    private final String fieldName;
+    private final Config.FieldConfig config;
+
+    public SourceFileNameJsonProvider(Config.FieldConfig config) {
+        this(config, "sourceFileName");
+    }
+
+    public SourceFileNameJsonProvider(Config.FieldConfig config, String defaultName) {
+        this.config = config;
+        this.fieldName = config.fieldName.orElse(defaultName);
+    }
+
+    @Override
+    public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
+        JsonWritingUtils.writeStringField(generator, fieldName, event.getSourceFileName());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return config.enabled.orElse(false);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SourceLineNumberJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SourceLineNumberJsonProvider.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.io.IOException;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+import io.quarkiverse.loggingjson.Enabled;
+import io.quarkiverse.loggingjson.JsonGenerator;
+import io.quarkiverse.loggingjson.JsonProvider;
+import io.quarkiverse.loggingjson.JsonWritingUtils;
+import io.quarkiverse.loggingjson.config.Config;
+
+public class SourceLineNumberJsonProvider implements JsonProvider, Enabled {
+
+    private final String fieldName;
+    private final Config.FieldConfig config;
+
+    public SourceLineNumberJsonProvider(Config.FieldConfig config) {
+        this(config, "sourceLineNumber");
+    }
+
+    public SourceLineNumberJsonProvider(Config.FieldConfig config, String defaultName) {
+        this.config = config;
+        this.fieldName = config.fieldName.orElse(defaultName);
+    }
+
+    @Override
+    public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
+        JsonWritingUtils.writeNumberField(generator, fieldName, event.getSourceLineNumber());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return config.enabled.orElse(false);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SourceMethodNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SourceMethodNameJsonProvider.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.io.IOException;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+import io.quarkiverse.loggingjson.Enabled;
+import io.quarkiverse.loggingjson.JsonGenerator;
+import io.quarkiverse.loggingjson.JsonProvider;
+import io.quarkiverse.loggingjson.JsonWritingUtils;
+import io.quarkiverse.loggingjson.config.Config;
+
+public class SourceMethodNameJsonProvider implements JsonProvider, Enabled {
+
+    private final String fieldName;
+    private final Config.FieldConfig config;
+
+    public SourceMethodNameJsonProvider(Config.FieldConfig config) {
+        this(config, "sourceMethodName");
+    }
+
+    public SourceMethodNameJsonProvider(Config.FieldConfig config, String defaultName) {
+        this.config = config;
+        this.fieldName = config.fieldName.orElse(defaultName);
+    }
+
+    @Override
+    public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
+        JsonWritingUtils.writeStringField(generator, fieldName, event.getSourceMethodName());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return config.enabled.orElse(false);
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SourceClassNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SourceClassNameJsonProviderJsonbTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.util.Optional;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkiverse.loggingjson.config.Config;
+
+public class SourceClassNameJsonProviderJsonbTest extends JsonProviderBaseTest {
+    @Override
+    protected Type type() {
+        return Type.JSONB;
+    }
+
+    @Test
+    void testDefaultConfig() throws Exception {
+        final Config.FieldConfig config = new Config.FieldConfig();
+        config.fieldName = Optional.empty();
+        config.enabled = Optional.empty();
+        final SourceClassNameJsonProvider provider = new SourceClassNameJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.setSourceClassName("SourceClassNameJsonProviderTest");
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        String className = result.findValue("sourceClassName").asText();
+        Assertions.assertNotNull(className);
+        Assertions.assertFalse(className.isEmpty());
+        Assertions.assertEquals("SourceClassNameJsonProviderTest", className);
+        Assertions.assertFalse(provider.isEnabled());
+    }
+
+    @Test
+    void testCustomConfig() throws Exception {
+        final Config.FieldConfig config = new Config.FieldConfig();
+        config.fieldName = Optional.of("class");
+        config.enabled = Optional.of(false);
+        final SourceClassNameJsonProvider provider = new SourceClassNameJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.setSourceClassName("SourceClassNameJsonProviderTest");
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        String className = result.findValue("class").asText();
+        Assertions.assertNotNull(className);
+        Assertions.assertFalse(className.isEmpty());
+        Assertions.assertEquals("SourceClassNameJsonProviderTest", className);
+        Assertions.assertFalse(provider.isEnabled());
+
+        config.enabled = Optional.of(true);
+        Assertions.assertTrue(new SourceClassNameJsonProvider(config).isEnabled());
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SourceFileNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SourceFileNameJsonProviderJsonbTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.util.Optional;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkiverse.loggingjson.config.Config;
+
+public class SourceFileNameJsonProviderJsonbTest extends JsonProviderBaseTest {
+    @Override
+    protected Type type() {
+        return Type.JSONB;
+    }
+
+    @Test
+    void testDefaultConfig() throws Exception {
+        final Config.FieldConfig config = new Config.FieldConfig();
+        config.fieldName = Optional.empty();
+        config.enabled = Optional.empty();
+        final SourceFileNameJsonProvider provider = new SourceFileNameJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.setSourceFileName("SourceFileNameJsonProviderTest.java");
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        String fileName = result.findValue("sourceFileName").asText();
+        Assertions.assertNotNull(fileName);
+        Assertions.assertFalse(fileName.isEmpty());
+        Assertions.assertEquals("SourceFileNameJsonProviderTest.java", fileName);
+        Assertions.assertFalse(provider.isEnabled());
+    }
+
+    @Test
+    void testCustomConfig() throws Exception {
+        final Config.FieldConfig config = new Config.FieldConfig();
+        config.fieldName = Optional.of("file");
+        config.enabled = Optional.of(false);
+        final SourceFileNameJsonProvider provider = new SourceFileNameJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.setSourceFileName("SourceFileNameJsonProviderTest.java");
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        String fileName = result.findValue("file").asText();
+        Assertions.assertNotNull(fileName);
+        Assertions.assertFalse(fileName.isEmpty());
+        Assertions.assertEquals("SourceFileNameJsonProviderTest.java", fileName);
+        Assertions.assertFalse(provider.isEnabled());
+
+        config.enabled = Optional.of(true);
+        Assertions.assertTrue(new SourceFileNameJsonProvider(config).isEnabled());
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SourceLineNumberJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SourceLineNumberJsonProviderJsonbTest.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.util.Optional;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkiverse.loggingjson.config.Config;
+
+public class SourceLineNumberJsonProviderJsonbTest extends JsonProviderBaseTest {
+    @Override
+    protected Type type() {
+        return Type.JSONB;
+    }
+
+    @Test
+    void testDefaultConfig() throws Exception {
+        final Config.FieldConfig config = new Config.FieldConfig();
+        config.fieldName = Optional.empty();
+        config.enabled = Optional.empty();
+        final SourceLineNumberJsonProvider provider = new SourceLineNumberJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.setSourceLineNumber(42);
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        int lineNumber = result.findValue("sourceLineNumber").asInt();
+        Assertions.assertEquals(42, lineNumber);
+        Assertions.assertFalse(provider.isEnabled());
+    }
+
+    @Test
+    void testCustomConfig() throws Exception {
+        final Config.FieldConfig config = new Config.FieldConfig();
+        config.fieldName = Optional.of("line");
+        config.enabled = Optional.of(false);
+        final SourceLineNumberJsonProvider provider = new SourceLineNumberJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.setSourceLineNumber(42);
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        int lineNumber = result.findValue("line").asInt();
+        Assertions.assertEquals(42, lineNumber);
+        Assertions.assertFalse(provider.isEnabled());
+
+        config.enabled = Optional.of(true);
+        Assertions.assertTrue(new SourceLineNumberJsonProvider(config).isEnabled());
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SourceMethodNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SourceMethodNameJsonProviderJsonbTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.util.Optional;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkiverse.loggingjson.config.Config;
+
+public class SourceMethodNameJsonProviderJsonbTest extends JsonProviderBaseTest {
+    @Override
+    protected Type type() {
+        return Type.JSONB;
+    }
+
+    @Test
+    void testDefaultConfig() throws Exception {
+        final Config.FieldConfig config = new Config.FieldConfig();
+        config.fieldName = Optional.empty();
+        config.enabled = Optional.empty();
+        final SourceMethodNameJsonProvider provider = new SourceMethodNameJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.setSourceMethodName("foo");
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        String methodName = result.findValue("sourceMethodName").asText();
+        Assertions.assertNotNull(methodName);
+        Assertions.assertFalse(methodName.isEmpty());
+        Assertions.assertEquals("foo", methodName);
+        Assertions.assertFalse(provider.isEnabled());
+    }
+
+    @Test
+    void testCustomConfig() throws Exception {
+        final Config.FieldConfig config = new Config.FieldConfig();
+        config.fieldName = Optional.of("method");
+        config.enabled = Optional.of(false);
+        final SourceMethodNameJsonProvider provider = new SourceMethodNameJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.setSourceMethodName("foo");
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        String methodName = result.findValue("method").asText();
+        Assertions.assertNotNull(methodName);
+        Assertions.assertFalse(methodName.isEmpty());
+        Assertions.assertEquals("foo", methodName);
+        Assertions.assertFalse(provider.isEnabled());
+
+        config.enabled = Optional.of(true);
+        Assertions.assertTrue(new SourceMethodNameJsonProvider(config).isEnabled());
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/SourceClassNameJsonProviderJacksonTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/SourceClassNameJsonProviderJacksonTest.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.loggingjson.providers.jackson;
+
+import io.quarkiverse.loggingjson.providers.SourceClassNameJsonProviderJsonbTest;
+
+public class SourceClassNameJsonProviderJacksonTest extends SourceClassNameJsonProviderJsonbTest {
+    @Override
+    protected Type type() {
+        return Type.JACKSON;
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/SourceFileNameJsonProviderJacksonTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/SourceFileNameJsonProviderJacksonTest.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.loggingjson.providers.jackson;
+
+import io.quarkiverse.loggingjson.providers.SourceFileNameJsonProviderJsonbTest;
+
+public class SourceFileNameJsonProviderJacksonTest extends SourceFileNameJsonProviderJsonbTest {
+    @Override
+    protected Type type() {
+        return Type.JACKSON;
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/SourceLineNumberJsonProviderJacksonTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/SourceLineNumberJsonProviderJacksonTest.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.loggingjson.providers.jackson;
+
+import io.quarkiverse.loggingjson.providers.SourceLineNumberJsonProviderJsonbTest;
+
+public class SourceLineNumberJsonProviderJacksonTest extends SourceLineNumberJsonProviderJsonbTest {
+    @Override
+    protected Type type() {
+        return Type.JACKSON;
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/SourceMethodNameJsonProviderJacksonTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/SourceMethodNameJsonProviderJacksonTest.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.loggingjson.providers.jackson;
+
+import io.quarkiverse.loggingjson.providers.SourceMethodNameJsonProviderJsonbTest;
+
+public class SourceMethodNameJsonProviderJacksonTest extends SourceMethodNameJsonProviderJsonbTest {
+    @Override
+    protected Type type() {
+        return Type.JACKSON;
+    }
+}


### PR DESCRIPTION
The following fields are now supported:
* sourceClassName
* sourceMethodName
* sourceFileName
* sourceLineNumber

Since the LogRecord (or rather ExtLogRecord) class needs to inspect the call stack to determine these fields, and since this may be expensive, the new fields are disabled by default and must explicitly be enabled in the configuration.