### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-# Quarkus Logging Json
-Quarkus logging extension outputting the logging in json.
+# Quarkus Logging JSON
+Quarkus logging extension outputting the log messages in JSON.
+It supports the following formats: default, [Elastic Common Schema (ECS)](https://www.elastic.co/guide/en/ecs-logging/overview/current/intro.html).
 
 ## Version to use
-| Quarkus Version | Use version |
-|-------|-------|
-| 3.x.x | 3.x.x |
-| 2.x.x | 1.x.x, 2.x.x |
+| Quarkus Version | Use version  |
+|-----------------|--------------|
+| 3.x.x           | 3.x.x        |
+| 2.x.x           | 1.x.x, 2.x.x |
 
 # Configuration
 The extension is enabled by default for console, when added to the project.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -3,7 +3,8 @@
 
 include::./includes/attributes.adoc[]
 
-Quarkus logging extension outputting the logging in JSON.
+Quarkus logging extension outputting the log messages in JSON.
+It supports the following formats: default, https://www.elastic.co/guide/en/ecs-logging/overview/current/intro.html[Elastic Common Schema (ECS)].
 
 == Installation
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>quarkus-logging-json</artifactId>
     <name>Quarkus Logging JSON - Runtime</name>
-    <description>Logging in JSON with support for custom fields</description>
+    <description>Logging in JSON with support for custom fields and Elastic Common Schema (ECS)</description>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
I feel it's important to stress that the extension supports ECS.
In particular, the tagline on https://quarkus.io/extensions/io.quarkiverse.loggingjson/quarkus-logging-json/ (which appears to get pulled from the POM `<description>`) should contain the 'ECS' keyword.
A search for extensions supporting ECS i.e. https://quarkus.io/extensions/?search-regex=ecs should turn up this one.