### PR TITLE
Switch configuration to @ConfigMapping

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -73,9 +73,6 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
-                    <compilerArgs>
-                        <arg>-AlegacyConfigRoot=true</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/JsonFormatter.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/JsonFormatter.java
@@ -15,7 +15,7 @@ public class JsonFormatter extends ExtFormatter {
     public JsonFormatter(List<JsonProvider> providers, JsonFactory jsonFactory, Config config) {
         this.providers = providers;
         this.jsonFactory = jsonFactory;
-        this.recordDelimiter = config.recordDelimiter;
+        this.recordDelimiter = config.recordDelimiter();
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
@@ -23,23 +23,23 @@ public class LoggingJsonRecorder {
 
     public RuntimeValue<Optional<Formatter>> initializeConsoleJsonLogging(Config config,
             JsonFactory jsonFactory) {
-        return initializeJsonLogging(config.console, config, jsonFactory);
+        return initializeJsonLogging(config.console(), config, jsonFactory);
     }
 
     public RuntimeValue<Optional<Formatter>> initializeFileJsonLogging(Config config,
             JsonFactory jsonFactory) {
-        return initializeJsonLogging(config.file, config, jsonFactory);
+        return initializeJsonLogging(config.file(), config, jsonFactory);
     }
 
     public RuntimeValue<Optional<Formatter>> initializeJsonLogging(ConfigFormatter formatter, Config config,
             JsonFactory jsonFactory) {
-        if (formatter == null || !formatter.isEnabled()) {
+        if (formatter == null || !formatter.enable()) {
             return new RuntimeValue<>(Optional.empty());
         }
 
         List<JsonProvider> providers;
 
-        if (config.logFormat == Config.LogFormat.ECS) {
+        if (config.logFormat() == Config.LogFormat.ECS) {
             providers = ecsFormat(config);
         } else {
             providers = defaultFormat(config);
@@ -68,42 +68,42 @@ public class LoggingJsonRecorder {
 
     private List<JsonProvider> defaultFormat(Config config) {
         List<JsonProvider> providers = new ArrayList<>();
-        providers.add(new TimestampJsonProvider(config.fields.timestamp));
-        providers.add(new SequenceJsonProvider(config.fields.sequence));
-        providers.add(new LoggerClassNameJsonProvider(config.fields.loggerClassName));
-        providers.add(new LoggerNameJsonProvider(config.fields.loggerName));
-        providers.add(new LogLevelJsonProvider(config.fields.level));
-        providers.add(new MessageJsonProvider(config.fields.message));
-        providers.add(new ThreadNameJsonProvider(config.fields.threadName));
-        providers.add(new ThreadIdJsonProvider(config.fields.threadId));
-        providers.add(new MDCJsonProvider(config.fields.mdc));
-        providers.add(new NDCJsonProvider(config.fields.ndc));
-        providers.add(new HostNameJsonProvider(config.fields.hostname));
-        providers.add(new ProcessNameJsonProvider(config.fields.processName));
-        providers.add(new ProcessIdJsonProvider(config.fields.processId));
-        providers.add(new StackTraceJsonProvider(config.fields.stackTrace));
-        providers.add(new ErrorTypeJsonProvider(config.fields.errorType));
-        providers.add(new ErrorMessageJsonProvider(config.fields.errorMessage));
-        providers.add(new ArgumentsJsonProvider(config.fields.arguments));
-        providers.add(new AdditionalFieldsJsonProvider(config.additionalField));
+        providers.add(new TimestampJsonProvider(config.fields().timestamp()));
+        providers.add(new SequenceJsonProvider(config.fields().sequence()));
+        providers.add(new LoggerClassNameJsonProvider(config.fields().loggerClassName()));
+        providers.add(new LoggerNameJsonProvider(config.fields().loggerName()));
+        providers.add(new LogLevelJsonProvider(config.fields().level()));
+        providers.add(new MessageJsonProvider(config.fields().message()));
+        providers.add(new ThreadNameJsonProvider(config.fields().threadName()));
+        providers.add(new ThreadIdJsonProvider(config.fields().threadId()));
+        providers.add(new MDCJsonProvider(config.fields().mdc()));
+        providers.add(new NDCJsonProvider(config.fields().ndc()));
+        providers.add(new HostNameJsonProvider(config.fields().hostname()));
+        providers.add(new ProcessNameJsonProvider(config.fields().processName()));
+        providers.add(new ProcessIdJsonProvider(config.fields().processId()));
+        providers.add(new StackTraceJsonProvider(config.fields().stackTrace()));
+        providers.add(new ErrorTypeJsonProvider(config.fields().errorType()));
+        providers.add(new ErrorMessageJsonProvider(config.fields().errorMessage()));
+        providers.add(new ArgumentsJsonProvider(config.fields().arguments()));
+        providers.add(new AdditionalFieldsJsonProvider(config.additionalField()));
         return providers;
     }
 
     private List<JsonProvider> ecsFormat(Config config) {
         List<JsonProvider> providers = new ArrayList<>();
-        providers.add(new TimestampJsonProvider(config.fields.timestamp, "@timestamp"));
-        providers.add(new LoggerNameJsonProvider(config.fields.loggerName, "log.logger"));
-        providers.add(new LogLevelJsonProvider(config.fields.level, "log.level"));
-        providers.add(new ThreadNameJsonProvider(config.fields.threadName, "process.thread.name"));
-        providers.add(new ThreadIdJsonProvider(config.fields.threadId, "process.thread.id"));
-        providers.add(new MDCJsonProvider(config.fields.mdc));
-        providers.add(new HostNameJsonProvider(config.fields.hostname, "host.name"));
-        providers.add(new StackTraceJsonProvider(config.fields.stackTrace, "error.stack_trace"));
-        providers.add(new ErrorTypeJsonProvider(config.fields.errorType, "error.type"));
-        providers.add(new ErrorMessageJsonProvider(config.fields.errorMessage, "error.message"));
-        providers.add(new ArgumentsJsonProvider(config.fields.arguments));
-        providers.add(new AdditionalFieldsJsonProvider(config.additionalField));
-        providers.add(new MessageJsonProvider(config.fields.message));
+        providers.add(new TimestampJsonProvider(config.fields().timestamp(), "@timestamp"));
+        providers.add(new LoggerNameJsonProvider(config.fields().loggerName(), "log.logger"));
+        providers.add(new LogLevelJsonProvider(config.fields().level(), "log.level"));
+        providers.add(new ThreadNameJsonProvider(config.fields().threadName(), "process.thread.name"));
+        providers.add(new ThreadIdJsonProvider(config.fields().threadId(), "process.thread.id"));
+        providers.add(new MDCJsonProvider(config.fields().mdc()));
+        providers.add(new HostNameJsonProvider(config.fields().hostname(), "host.name"));
+        providers.add(new StackTraceJsonProvider(config.fields().stackTrace(), "error.stack_trace"));
+        providers.add(new ErrorTypeJsonProvider(config.fields().errorType(), "error.type"));
+        providers.add(new ErrorMessageJsonProvider(config.fields().errorMessage(), "error.message"));
+        providers.add(new ArgumentsJsonProvider(config.fields().arguments()));
+        providers.add(new AdditionalFieldsJsonProvider(config.additionalField()));
+        providers.add(new MessageJsonProvider(config.fields().message()));
         providers.add(new StaticKeyValueProvider("ecs.version", "1.12.1"));
         return providers;
     }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/Config.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/Config.java
@@ -6,237 +6,240 @@ import java.util.Optional;
 import io.quarkiverse.loggingjson.providers.ArgumentsJsonProvider;
 import io.quarkiverse.loggingjson.providers.StructuredArgument;
 import io.quarkus.runtime.annotations.*;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "log.json")
-public class Config {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.log.json")
+public interface Config {
     /**
      * Configuration properties for console formatter.
      */
-    @ConfigItem(name = "console")
-    public ConfigConsole console;
+    ConfigConsole console();
 
     /**
      * Configuration properties for file formatter.
      */
-    @ConfigItem(name = "file")
-    public ConfigFile file;
+    ConfigFile file();
 
     /**
      * Configuration properties to customize fields
      */
-    @ConfigItem
-    public FieldsConfig fields;
+    FieldsConfig fields();
+
     /**
      * Enable "pretty printing" of the JSON record. Note that some JSON parsers will fail to read pretty printed output.
      */
-    @ConfigItem
-    public boolean prettyPrint;
+    @WithDefault("false")
+    boolean prettyPrint();
+
     /**
      * The special end-of-record delimiter to be used. By default, newline delimiter is used.
      */
-    @ConfigItem(defaultValue = "\n")
-    public String recordDelimiter;
+    @WithDefault("\n")
+    String recordDelimiter();
+
     /**
      * For adding fields to the json output directly from the config.
      */
-    @ConfigItem
     @ConfigDocMapKey("field-name")
     @ConfigDocSection
-    public Map<String, AdditionalFieldConfig> additionalField;
+    Map<String, AdditionalFieldConfig> additionalField();
 
     /**
      * Support changing logging format.
      */
-    @ConfigItem(defaultValue = "DEFAULT")
-    public LogFormat logFormat;
+    @WithDefault("DEFAULT")
+    LogFormat logFormat();
 
     @ConfigGroup
-    public static class FieldsConfig {
+    public interface FieldsConfig {
         /**
          * Used to customize {@link ArgumentsJsonProvider}
          */
-        @ConfigItem
-        public ArgumentsConfig arguments;
+        ArgumentsConfig arguments();
+
         /**
          * Options for timestamp.
          */
-        @ConfigItem
-        public TimestampField timestamp;
+        TimestampField timestamp();
+
         /**
          * Options for hostname.
          */
-        @ConfigItem
-        public FieldConfig hostname;
+        FieldConfig hostname();
+
         /**
          * Options for sequence.
          */
-        @ConfigItem
-        public FieldConfig sequence;
+        FieldConfig sequence();
+
         /**
          * Options for loggerClassName.
          */
-        @ConfigItem
-        public FieldConfig loggerClassName;
+        FieldConfig loggerClassName();
+
         /**
          * Options for loggerName.
          */
-        @ConfigItem
-        public FieldConfig loggerName;
+        FieldConfig loggerName();
+
         /**
          * Options for level.
          */
-        @ConfigItem
-        public FieldConfig level;
+        FieldConfig level();
+
         /**
          * Options for message.
          */
-        @ConfigItem
-        public FieldConfig message;
+        FieldConfig message();
+
         /**
          * Options for threadName.
          */
-        @ConfigItem
-        public FieldConfig threadName;
+        FieldConfig threadName();
+
         /**
          * Options for threadId.
          */
-        @ConfigItem
-        public FieldConfig threadId;
+        FieldConfig threadId();
+
         /**
          * Options for mdc.
          */
-        @ConfigItem
-        public MDCConfig mdc;
+        MDCConfig mdc();
+
         /**
          * Options for ndc.
          */
-        @ConfigItem
-        public FieldConfig ndc;
+        FieldConfig ndc();
+
         /**
          * Options for processName.
          */
-        @ConfigItem
-        public FieldConfig processName;
+        FieldConfig processName();
+
         /**
          * Options for processId.
          */
-        @ConfigItem
-        public FieldConfig processId;
+        FieldConfig processId();
+
         /**
          * Options for stackTrace.
          */
-        @ConfigItem
-        public FieldConfig stackTrace;
+        FieldConfig stackTrace();
+
         /**
          * Options for errorType.
          */
-        @ConfigItem
-        public FieldConfig errorType;
+        FieldConfig errorType();
+
         /**
          * Options for errorMessage.
          */
-        @ConfigItem
-        public FieldConfig errorMessage;
+        FieldConfig errorMessage();
     }
 
     @ConfigGroup
-    public static class FieldConfig {
+    public interface FieldConfig {
         /**
          * Used to change the json key for the field.
          */
-        @ConfigItem
-        public Optional<String> fieldName;
+        Optional<String> fieldName();
+
         /**
          * Enable or disable the field.
          */
-        @ConfigItem
-        public Optional<Boolean> enabled;
+        Optional<Boolean> enabled();
     }
 
     @ConfigGroup
-    public static class MDCConfig {
+    public interface MDCConfig {
         /**
          * Used to change the json key for the field.
          */
-        @ConfigItem
-        public Optional<String> fieldName;
+        Optional<String> fieldName();
+
         /**
          * Enable or disable the field.
          */
-        @ConfigItem
-        public Optional<Boolean> enabled;
+        Optional<Boolean> enabled();
+
         /**
          * Will write the values at the top level of the JSON log object.
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean flatFields;
+        @WithDefault("false")
+        boolean flatFields();
     }
 
     @ConfigGroup
-    public static class TimestampField {
+    public interface TimestampField {
         /**
          * Used to change the json key for the field.
          */
-        @ConfigItem
-        public Optional<String> fieldName;
+        Optional<String> fieldName();
+
         /**
          * The date format to use. The special string "default" indicates that the default format should be used.
          */
-        @ConfigItem(defaultValue = "default")
-        public String dateFormat;
+        @WithDefault("default")
+        String dateFormat();
+
         /**
          * The zone to use when formatting the timestamp.
          */
-        @ConfigItem(defaultValue = "default")
-        public String zoneId;
+        @WithDefault("default")
+        String zoneId();
+
         /**
          * Enable or disable the field.
          */
-        @ConfigItem
-        public Optional<Boolean> enabled;
+        Optional<Boolean> enabled();
     }
 
     @ConfigGroup
-    public static class ArgumentsConfig {
+    public interface ArgumentsConfig {
 
         /**
          * Used to wrap arguments in an json object, with this fieldName on root json.
          */
-        @ConfigItem
-        public Optional<String> fieldName = Optional.empty();
+        Optional<String> fieldName();
+
         /**
          * Enable output of structured logging arguments
          * {@link StructuredArgument},
          * default is true.
          */
-        @ConfigItem(defaultValue = "true")
-        public boolean includeStructuredArguments;
+        @WithDefault("true")
+        boolean includeStructuredArguments();
+
         /**
          * Enable output of non structured logging arguments, default is false.
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean includeNonStructuredArguments;
+        @WithDefault("false")
+        boolean includeNonStructuredArguments();
+
         /**
          * What prefix to use, when outputting non structured arguments. Default is `arg`, example key for first argument will
          * be `arg0`.
          */
-        @ConfigItem(defaultValue = "arg")
-        public String nonStructuredArgumentsFieldPrefix;
+        @WithDefault("arg")
+        String nonStructuredArgumentsFieldPrefix();
     }
 
     @ConfigGroup
-    public static class AdditionalFieldConfig {
+    public interface AdditionalFieldConfig {
         /**
          * Additional field value.
          */
-        @ConfigItem
-        public String value;
+        String value();
+
         /**
          * Type of the field, default is STRING.
          * Supported types: STRING, INT, LONG, FLOAT, DOUBLE.
          */
-        @ConfigItem(defaultValue = "STRING")
-        public AdditionalFieldType type;
+        @WithDefault("STRING")
+        AdditionalFieldType type();
     }
 
     public enum AdditionalFieldType {

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigConsole.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigConsole.java
@@ -1,18 +1,13 @@
 package io.quarkiverse.loggingjson.config;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
-public class ConfigConsole implements ConfigFormatter {
+public interface ConfigConsole extends ConfigFormatter {
     /**
      * Determine whether to enable the JSON console formatting extension, which disables "normal" console formatting.
      */
-    @ConfigItem(defaultValue = "true")
-    boolean enable;
-
-    @Override
-    public boolean isEnabled() {
-        return enable;
-    }
+    @WithDefault("true")
+    boolean enable();
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigFile.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigFile.java
@@ -1,18 +1,13 @@
 package io.quarkiverse.loggingjson.config;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
-public class ConfigFile implements ConfigFormatter {
+public interface ConfigFile extends ConfigFormatter {
     /**
      * Determine whether to enable the JSON file formatting extension, which disables "normal" file formatting.
      */
-    @ConfigItem(defaultValue = "false")
-    boolean enable;
-
-    @Override
-    public boolean isEnabled() {
-        return enable;
-    }
+    @WithDefault("false")
+    boolean enable();
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigFormatter.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigFormatter.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.loggingjson.config;
 
+import io.quarkus.runtime.annotations.ConfigDocIgnore;
+
 public interface ConfigFormatter {
 
-    boolean isEnabled();
+    @ConfigDocIgnore
+    boolean enable();
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/AdditionalFieldsJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/AdditionalFieldsJsonProvider.java
@@ -23,8 +23,8 @@ public class AdditionalFieldsJsonProvider implements JsonProvider, Enabled {
     public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
         for (Map.Entry<String, Config.AdditionalFieldConfig> entry : fields.entrySet()) {
             final String fieldName = entry.getKey();
-            final String fieldValue = entry.getValue().value;
-            switch (entry.getValue().type) {
+            final String fieldValue = entry.getValue().value();
+            switch (entry.getValue().type()) {
                 case STRING:
                     generator.writeStringField(fieldName, fieldValue);
                     break;

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ArgumentsJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ArgumentsJsonProvider.java
@@ -17,10 +17,10 @@ public class ArgumentsJsonProvider implements JsonProvider, Enabled {
     private final Optional<String> fieldName;
 
     public ArgumentsJsonProvider(Config.ArgumentsConfig config) {
-        this.fieldName = config.fieldName;
-        this.includeStructuredArguments = config.includeStructuredArguments;
-        this.includeNonStructuredArguments = config.includeNonStructuredArguments;
-        this.nonStructuredArgumentsFieldPrefix = config.nonStructuredArgumentsFieldPrefix;
+        this.fieldName = config.fieldName();
+        this.includeStructuredArguments = config.includeStructuredArguments();
+        this.includeNonStructuredArguments = config.includeNonStructuredArguments();
+        this.nonStructuredArgumentsFieldPrefix = config.nonStructuredArgumentsFieldPrefix();
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ErrorMessageJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ErrorMessageJsonProvider.java
@@ -18,7 +18,7 @@ public class ErrorMessageJsonProvider implements JsonProvider, Enabled {
 
     public ErrorMessageJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -30,6 +30,6 @@ public class ErrorMessageJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ErrorTypeJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ErrorTypeJsonProvider.java
@@ -18,7 +18,7 @@ public class ErrorTypeJsonProvider implements JsonProvider, Enabled {
 
     public ErrorTypeJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -30,6 +30,6 @@ public class ErrorTypeJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/HostNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/HostNameJsonProvider.java
@@ -18,7 +18,7 @@ public class HostNameJsonProvider implements JsonProvider, Enabled {
 
     public HostNameJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -30,6 +30,6 @@ public class HostNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LogLevelJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LogLevelJsonProvider.java
@@ -17,7 +17,7 @@ public class LogLevelJsonProvider implements JsonProvider, Enabled {
 
     public LogLevelJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -27,6 +27,6 @@ public class LogLevelJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LoggerClassNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LoggerClassNameJsonProvider.java
@@ -17,7 +17,7 @@ public class LoggerClassNameJsonProvider implements JsonProvider, Enabled {
 
     public LoggerClassNameJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("loggerClassName");
+        this.fieldName = config.fieldName().orElse("loggerClassName");
     }
 
     @Override
@@ -27,6 +27,6 @@ public class LoggerClassNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LoggerNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LoggerNameJsonProvider.java
@@ -17,7 +17,7 @@ public class LoggerNameJsonProvider implements JsonProvider, Enabled {
     }
 
     public LoggerNameJsonProvider(Config.FieldConfig config, String defaultName) {
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
         this.config = config;
     }
 
@@ -28,6 +28,6 @@ public class LoggerNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MDCJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MDCJsonProvider.java
@@ -17,10 +17,10 @@ public class MDCJsonProvider implements JsonProvider, Enabled {
 
     public MDCJsonProvider(Config.MDCConfig config) {
         this.config = config;
-        if (config.flatFields) {
+        if (config.flatFields()) {
             this.fieldName = null;
         } else {
-            this.fieldName = config.fieldName.orElse("mdc");
+            this.fieldName = config.fieldName().orElse("mdc");
         }
     }
 
@@ -31,6 +31,6 @@ public class MDCJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MessageJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MessageJsonProvider.java
@@ -18,7 +18,7 @@ public class MessageJsonProvider extends ExtFormatter implements JsonProvider, E
 
     public MessageJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("message");
+        this.fieldName = config.fieldName().orElse("message");
     }
 
     @Override
@@ -33,6 +33,6 @@ public class MessageJsonProvider extends ExtFormatter implements JsonProvider, E
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/NDCJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/NDCJsonProvider.java
@@ -17,7 +17,7 @@ public class NDCJsonProvider implements JsonProvider, Enabled {
 
     public NDCJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("ndc");
+        this.fieldName = config.fieldName().orElse("ndc");
     }
 
     @Override
@@ -29,6 +29,6 @@ public class NDCJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ProcessIdJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ProcessIdJsonProvider.java
@@ -17,7 +17,7 @@ public class ProcessIdJsonProvider implements JsonProvider, Enabled {
 
     public ProcessIdJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("processId");
+        this.fieldName = config.fieldName().orElse("processId");
     }
 
     @Override
@@ -29,6 +29,6 @@ public class ProcessIdJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ProcessNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ProcessNameJsonProvider.java
@@ -17,7 +17,7 @@ public class ProcessNameJsonProvider implements JsonProvider, Enabled {
 
     public ProcessNameJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("processName");
+        this.fieldName = config.fieldName().orElse("processName");
     }
 
     @Override
@@ -29,6 +29,6 @@ public class ProcessNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SequenceJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SequenceJsonProvider.java
@@ -17,7 +17,7 @@ public class SequenceJsonProvider implements JsonProvider, Enabled {
 
     public SequenceJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("sequence");
+        this.fieldName = config.fieldName().orElse("sequence");
     }
 
     @Override
@@ -27,6 +27,6 @@ public class SequenceJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/StackTraceJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/StackTraceJsonProvider.java
@@ -19,7 +19,7 @@ public class StackTraceJsonProvider implements JsonProvider, Enabled {
 
     public StackTraceJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -33,6 +33,6 @@ public class StackTraceJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ThreadIdJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ThreadIdJsonProvider.java
@@ -21,7 +21,7 @@ public class ThreadIdJsonProvider implements JsonProvider, Enabled {
 
     public ThreadIdJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -31,6 +31,6 @@ public class ThreadIdJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ThreadNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ThreadNameJsonProvider.java
@@ -21,7 +21,7 @@ public class ThreadNameJsonProvider implements JsonProvider, Enabled {
 
     public ThreadNameJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -31,6 +31,6 @@ public class ThreadNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/TimestampJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/TimestampJsonProvider.java
@@ -25,17 +25,17 @@ public class TimestampJsonProvider implements JsonProvider, Enabled {
 
     public TimestampJsonProvider(Config.TimestampField config, String defaultName) {
         this.config = config;
-        fieldName = config.fieldName.orElse(defaultName);
+        fieldName = config.fieldName().orElse(defaultName);
 
         ZoneId zoneId;
-        if (config.zoneId == null || "default".equals(config.zoneId)) {
+        if (config.zoneId() == null || "default".equals(config.zoneId())) {
             zoneId = ZoneId.systemDefault();
         } else {
-            zoneId = ZoneId.of(config.zoneId);
+            zoneId = ZoneId.of(config.zoneId());
         }
 
-        if (config.dateFormat != null && !config.dateFormat.equals("default")) {
-            dateTimeFormatter = DateTimeFormatter.ofPattern(config.dateFormat).withZone(zoneId);
+        if (config.dateFormat() != null && !config.dateFormat().equals("default")) {
+            dateTimeFormatter = DateTimeFormatter.ofPattern(config.dateFormat()).withZone(zoneId);
         } else {
             dateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId);
         }
@@ -50,6 +50,6 @@ public class TimestampJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/AdditionalFieldsJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/AdditionalFieldsJsonProviderJsonbTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
 import io.quarkiverse.loggingjson.config.Config;
+import io.quarkiverse.loggingjson.config.Config.AdditionalFieldType;
 
 public class AdditionalFieldsJsonProviderJsonbTest extends JsonProviderBaseTest {
     @Override
@@ -59,9 +60,18 @@ public class AdditionalFieldsJsonProviderJsonbTest extends JsonProviderBaseTest 
     }
 
     private Config.AdditionalFieldConfig additionalFieldConfig(String value, Config.AdditionalFieldType type) {
-        final Config.AdditionalFieldConfig config = new Config.AdditionalFieldConfig();
-        config.value = value;
-        config.type = type;
+        final Config.AdditionalFieldConfig config = new Config.AdditionalFieldConfig() {
+
+            @Override
+            public String value() {
+                return value;
+            }
+
+            @Override
+            public AdditionalFieldType type() {
+                return type;
+            }
+        };
         return config;
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ArgumentsJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ArgumentsJsonProviderJsonbTest.java
@@ -22,11 +22,28 @@ public class ArgumentsJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.ArgumentsConfig config = new Config.ArgumentsConfig();
-        config.fieldName = Optional.empty();
-        config.includeStructuredArguments = true;
-        config.includeNonStructuredArguments = false;
-        config.nonStructuredArgumentsFieldPrefix = "arg";
+        final Config.ArgumentsConfig config = new Config.ArgumentsConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean includeStructuredArguments() {
+                return true;
+            }
+
+            @Override
+            public boolean includeNonStructuredArguments() {
+                return false;
+            }
+
+            @Override
+            public String nonStructuredArgumentsFieldPrefix() {
+                return "arg";
+            }
+        };
         final ArgumentsJsonProvider provider = new ArgumentsJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -50,11 +67,28 @@ public class ArgumentsJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfigShortCircuit() throws Exception {
-        final Config.ArgumentsConfig config = new Config.ArgumentsConfig();
-        config.fieldName = Optional.empty();
-        config.includeStructuredArguments = false;
-        config.includeNonStructuredArguments = false;
-        config.nonStructuredArgumentsFieldPrefix = "arg";
+        final Config.ArgumentsConfig config = new Config.ArgumentsConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean includeStructuredArguments() {
+                return false;
+            }
+
+            @Override
+            public boolean includeNonStructuredArguments() {
+                return false;
+            }
+
+            @Override
+            public String nonStructuredArgumentsFieldPrefix() {
+                return "arg";
+            }
+        };
         final ArgumentsJsonProvider provider = new ArgumentsJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -70,11 +104,28 @@ public class ArgumentsJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfigWrapInObject() throws Exception {
-        final Config.ArgumentsConfig config = new Config.ArgumentsConfig();
-        config.fieldName = Optional.of("arguments");
-        config.includeStructuredArguments = true;
-        config.includeNonStructuredArguments = true;
-        config.nonStructuredArgumentsFieldPrefix = "arg";
+        final Config.ArgumentsConfig config = new Config.ArgumentsConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("arguments");
+            }
+
+            @Override
+            public boolean includeStructuredArguments() {
+                return true;
+            }
+
+            @Override
+            public boolean includeNonStructuredArguments() {
+                return true;
+            }
+
+            @Override
+            public String nonStructuredArgumentsFieldPrefix() {
+                return "arg";
+            }
+        };
         final ArgumentsJsonProvider provider = new ArgumentsJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ErrorMessageJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ErrorMessageJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class ErrorMessageJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ErrorMessageJsonProvider provider = new ErrorMessageJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing errorMessage");
@@ -39,9 +48,18 @@ public class ErrorMessageJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("em");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("em");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final ErrorMessageJsonProvider provider = new ErrorMessageJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing errorMessage");
@@ -56,7 +74,18 @@ public class ErrorMessageJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("Testing errorMessage", em);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("em");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new ErrorMessageJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ErrorTypeJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ErrorTypeJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class ErrorTypeJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ErrorTypeJsonProvider provider = new ErrorTypeJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing errorType");
@@ -39,9 +48,18 @@ public class ErrorTypeJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("et");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("et");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final ErrorTypeJsonProvider provider = new ErrorTypeJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing errorType");
@@ -56,7 +74,18 @@ public class ErrorTypeJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("java.lang.RuntimeException", et);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("et");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new ErrorTypeJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/HostNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/HostNameJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class HostNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final HostNameJsonProvider provider = new HostNameJsonProvider(config);
 
         final JsonNode result = getResultAsJsonNode(provider, new ExtLogRecord(Level.ALL, "", ""));
@@ -34,9 +43,18 @@ public class HostNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("host");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("host");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final HostNameJsonProvider provider = new HostNameJsonProvider(config);
 
         final JsonNode result = getResultAsJsonNode(provider, new ExtLogRecord(Level.ALL, "", ""));
@@ -46,7 +64,18 @@ public class HostNameJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertFalse(hostName.isEmpty());
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("host");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new HostNameJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LogLevelJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LogLevelJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class LogLevelJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final LogLevelJsonProvider provider = new LogLevelJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -36,9 +45,18 @@ public class LogLevelJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("logLevel");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("logLevel");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final LogLevelJsonProvider provider = new LogLevelJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -50,7 +68,18 @@ public class LogLevelJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("ALL", logger);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("logLevel");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new LogLevelJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LoggerClassNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LoggerClassNameJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class LoggerClassNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final LoggerClassNameJsonProvider provider = new LoggerClassNameJsonProvider(config);
 
         final JsonNode result = getResultAsJsonNode(provider,
@@ -36,9 +45,18 @@ public class LoggerClassNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("loggerClass");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("loggerClass");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final LoggerClassNameJsonProvider provider = new LoggerClassNameJsonProvider(config);
 
         final JsonNode result = getResultAsJsonNode(provider,
@@ -50,7 +68,18 @@ public class LoggerClassNameJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("LoggerClassNameJsonProviderTest", loggerClass);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("loggerClass");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new LoggerClassNameJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LoggerNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LoggerNameJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class LoggerNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final LoggerNameJsonProvider provider = new LoggerNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -37,9 +46,18 @@ public class LoggerNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("logger");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("logger");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final LoggerNameJsonProvider provider = new LoggerNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -52,7 +70,18 @@ public class LoggerNameJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("LoggerNameJsonProviderTest", logger);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("logger");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new LoggerNameJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MDCJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MDCJsonProviderJsonbTest.java
@@ -21,9 +21,23 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.MDCConfig config = new Config.MDCConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.MDCConfig config = new Config.MDCConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean flatFields() {
+                return false;
+            }
+        };
         final MDCJsonProvider provider = new MDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -42,9 +56,23 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.MDCConfig config = new Config.MDCConfig();
-        config.fieldName = Optional.of("m");
-        config.enabled = Optional.of(false);
+        Config.MDCConfig config = new Config.MDCConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("m");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+
+            @Override
+            public boolean flatFields() {
+                return false;
+            }
+        };
         final MDCJsonProvider provider = new MDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -61,16 +89,45 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.MDCConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("m");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+
+            @Override
+            public boolean flatFields() {
+                return false;
+            }
+        };
         Assertions.assertTrue(new MDCJsonProvider(config).isEnabled());
     }
 
     @Test
     void testFlatCustomConfig() throws Exception {
-        final Config.MDCConfig config = new Config.MDCConfig();
-        config.fieldName = Optional.of("m");
-        config.enabled = Optional.empty();
-        config.flatFields = true;
+        final Config.MDCConfig config = new Config.MDCConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("m");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean flatFields() {
+                return true;
+            }
+        };
         final MDCJsonProvider provider = new MDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MessageJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MessageJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class MessageJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final MessageJsonProvider provider = new MessageJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "TestMessage {0}", "");
@@ -38,9 +47,18 @@ public class MessageJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("msg");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("msg");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final MessageJsonProvider provider = new MessageJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "TestMessage {0}", "");
@@ -53,7 +71,18 @@ public class MessageJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("TestMessage param0", msg);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("msg");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new MessageJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/NDCJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/NDCJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class NDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final NDCJsonProvider provider = new NDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -37,9 +46,18 @@ public class NDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("n");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("n");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final NDCJsonProvider provider = new NDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -52,7 +70,18 @@ public class NDCJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("NDCTest", n);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("n");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new NDCJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ProcessIdJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ProcessIdJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class ProcessIdJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ProcessIdJsonProvider provider = new ProcessIdJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -35,9 +44,18 @@ public class ProcessIdJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("pid");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("pid");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final ProcessIdJsonProvider provider = new ProcessIdJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -48,7 +66,18 @@ public class ProcessIdJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals(23847, pid);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("pid");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new ProcessIdJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ProcessNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ProcessNameJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class ProcessNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ProcessNameJsonProvider provider = new ProcessNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -37,9 +46,18 @@ public class ProcessNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("pn");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("pn");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final ProcessNameJsonProvider provider = new ProcessNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -52,7 +70,18 @@ public class ProcessNameJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("TestProcess", pn);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("pn");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new ProcessNameJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SequenceJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SequenceJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class SequenceJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final SequenceJsonProvider provider = new SequenceJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -35,9 +44,18 @@ public class SequenceJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("seq");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("seq");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final SequenceJsonProvider provider = new SequenceJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -48,7 +66,18 @@ public class SequenceJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals(4356, seq);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("seq");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new SequenceJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/StackTraceJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/StackTraceJsonProviderJsonbTest.java
@@ -21,9 +21,18 @@ public class StackTraceJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final StackTraceJsonProvider provider = new StackTraceJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing stackTrace");
@@ -44,9 +53,18 @@ public class StackTraceJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("st");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("st");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final StackTraceJsonProvider provider = new StackTraceJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing stackTrace");
@@ -64,7 +82,18 @@ public class StackTraceJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals(out.toString(), st);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("st");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new StackTraceJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ThreadIdJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ThreadIdJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class ThreadIdJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ThreadIdJsonProvider provider = new ThreadIdJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -35,9 +44,18 @@ public class ThreadIdJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("tid");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("tid");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final ThreadIdJsonProvider provider = new ThreadIdJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -48,7 +66,18 @@ public class ThreadIdJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals(3249, tid);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("tid");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new ThreadIdJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ThreadNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ThreadNameJsonProviderJsonbTest.java
@@ -19,9 +19,18 @@ public class ThreadNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ThreadNameJsonProvider provider = new ThreadNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -37,9 +46,18 @@ public class ThreadNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("tn");
-        config.enabled = Optional.of(false);
+        Config.FieldConfig config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("tn");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
         final ThreadNameJsonProvider provider = new ThreadNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -52,7 +70,18 @@ public class ThreadNameJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals("TestThread", tn);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config = new Config.FieldConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("tn");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(true);
+            }
+        };
         Assertions.assertTrue(new ThreadNameJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/TimestampJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/TimestampJsonProviderJsonbTest.java
@@ -25,10 +25,28 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.empty();
-        config.dateFormat = "default";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
 
         OffsetDateTime beforeLog = OffsetDateTime.now().minusSeconds(1);
@@ -44,10 +62,28 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.of("@timestamp");
-        config.dateFormat = "dd-MM-yyyy HH:mm:ss.SSS";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("@timestamp");
+            }
+
+            @Override
+            public String dateFormat() {
+                return "dd-MM-yyyy HH:mm:ss.SSS";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
 
         LocalDateTime beforeLog = LocalDateTime.now().minusSeconds(1);
@@ -63,22 +99,81 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfigDisabled() {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
-        final TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
+        Config.TimestampField config = new Config.TimestampField() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
+        TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
         Assertions.assertTrue(timestampJsonProvider.isEnabled());
 
-        config.enabled = Optional.of(false);
+        config = new Config.TimestampField() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.of(false);
+            }
+        };
+        timestampJsonProvider = new TimestampJsonProvider(config);
         Assertions.assertFalse(timestampJsonProvider.isEnabled());
     }
 
     @Test
     void testCustomDateFormatConfigFail() {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.of("@timestamp");
-        config.dateFormat = "sdkfjl";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("@timestamp");
+            }
+
+            @Override
+            public String dateFormat() {
+                return "sdkfjl";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
 
         try {
             new TimestampJsonProvider(config);
@@ -89,10 +184,28 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomZoneIdConfig() throws Exception {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.of("timestamp");
-        config.zoneId = "Antarctica/Davis";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("timestamp");
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "Antarctica/Davis";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
 
         ZonedDateTime beforeLog = ZonedDateTime.now().minusSeconds(1).withZoneSameInstant(ZoneId.of("+7"));
@@ -109,10 +222,28 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomZoneIdConfigFail() {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.of("timestamp");
-        config.zoneId = "sdkfjl";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("timestamp");
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "sdkfjl";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
 
         try {
             new TimestampJsonProvider(config);


### PR DESCRIPTION
We plan to retire the legacy config classes approach at a future point so let's migrate to @ConfigMapping.

I had to adjust the tests as the new config is immutable and based on interfaces but it should be pretty straightforward.

Probably a good idea to merge it quickly as this PR is prone to conflicts.