### PR TITLE
Migrate to ConfigMapping configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,16 @@ public class MyJsonProvider implements JsonProvider {
 }
 ```
 
-## Property Relocation
+## Configuration Properties Relocation
 
-This project includes a configuration property relocation mechanism using SmallRye Config's `RelocateConfigSourceInterceptor`. 
-It supports backward compatibility by allowing both old and new property names:
+In 3.2.0, two configuration properties were renamed to be more consistent with Quarkus configuration.
 
-- Old: `quarkus.log.console.json.enable` → New: `quarkus.log.console.json.enabled`
-- Old: `quarkus.log.file.json.enable` → New: `quarkus.log.file.json.enabled`
+- Old: `quarkus.log.json.console.enable` → New: `quarkus.log.json.console.enabled`
+- Old: `quarkus.log.json.file.enable` → New: `quarkus.log.json.file.enabled`
 
-When using the old property names, a log message will be generated advising to update to the new property names.
+A relocation/fallback mechanism has been added so the old properties are still supported
+but we recomment that you switch to the new ones
+(`quarkus update` will do it for you).
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Quarkus logging extension outputting the logging in json.
 
 # Configuration
 The extension is enabled by default for console, when added to the project.
-Console logging can be disabled using configuration: `quarkus.log.json.console.enable=false`
+Console logging can be disabled using configuration: `quarkus.log.json.console.enabled=false`
 
 To see additional configuration options take a look at [Config](https://quarkiverse.github.io/quarkiverse-docs/quarkus-logging-json/dev/index.html)
 
@@ -63,6 +63,16 @@ public class MyJsonProvider implements JsonProvider {
 }
 ```
 
+## Property Relocation
+
+This project includes a configuration property relocation mechanism using SmallRye Config's `RelocateConfigSourceInterceptor`. 
+It supports backward compatibility by allowing both old and new property names:
+
+- Old: `quarkus.log.console.json.enable` → New: `quarkus.log.console.json.enabled`
+- Old: `quarkus.log.file.json.enable` → New: `quarkus.log.file.json.enabled`
+
+When using the old property names, a log message will be generated advising to update to the new property names.
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -81,3 +91,5 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+`

--- a/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDeprecatedConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/loggingjson/deployment/JsonDeprecatedConfigTest.java
@@ -1,0 +1,63 @@
+package io.quarkiverse.loggingjson.deployment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import org.jboss.logmanager.handlers.ConsoleHandler;
+import org.jboss.logmanager.handlers.FileHandler;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.loggingjson.JsonFormatter;
+import io.quarkus.bootstrap.logging.InitialConfigurator;
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
+import io.quarkus.bootstrap.model.AppArtifact;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * In this test, we check that the feature is disabled as it is the only way to check the relocation/fallback works.
+ */
+class JsonDeprecatedConfigTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .setForcedDependencies(Collections.singletonList(
+                    new AppArtifact("io.quarkus", "quarkus-jackson", System.getProperty("test.quarkus.version"))))
+            .withConfigurationResource("application-json-deprecated-config.properties");
+
+    static {
+        System.setProperty("java.util.logging.manager", org.jboss.logmanager.LogManager.class.getName());
+    }
+
+    @Test
+    void testJsonLoggingDisabled() throws Exception {
+        LogManager logManager = LogManager.getLogManager();
+        Assertions.assertTrue(logManager instanceof org.jboss.logmanager.LogManager);
+
+        QuarkusDelayedHandler delayedHandler = InitialConfigurator.DELAYED_HANDLER;
+        Assertions.assertTrue(Arrays.asList(Logger.getLogger("").getHandlers()).contains(delayedHandler));
+        Assertions.assertEquals(Level.ALL, delayedHandler.getLevel());
+
+        Handler consoleHandler = Arrays.stream(delayedHandler.getHandlers())
+                .filter(h -> (h instanceof ConsoleHandler))
+                .findFirst().orElse(null);
+        Assertions.assertNotNull(consoleHandler);
+
+        Assertions.assertFalse(consoleHandler.getFormatter() instanceof JsonFormatter);
+
+        Handler fileHandler = Arrays.stream(delayedHandler.getHandlers())
+                .filter(h -> (h instanceof FileHandler))
+                .findFirst().orElse(null);
+        Assertions.assertNotNull(fileHandler);
+
+        Assertions.assertFalse(fileHandler.getFormatter() instanceof JsonFormatter);
+    }
+}

--- a/deployment/src/test/resources/application-json-deprecated-config.properties
+++ b/deployment/src/test/resources/application-json-deprecated-config.properties
@@ -1,0 +1,8 @@
+quarkus.log.level=INFO
+quarkus.log.console.enable=true
+quarkus.log.console.level=WARNING
+quarkus.log.json.console.enable=false
+quarkus.log.json.fields.arguments.include-non-structured-arguments=true
+quarkus.log.json.additional-field.serviceName.value=deployment-test
+quarkus.log.file.enable=true
+quarkus.log.json.file.enable=false

--- a/deployment/src/test/resources/application-json-ecs.properties
+++ b/deployment/src/test/resources/application-json-ecs.properties
@@ -1,7 +1,7 @@
 quarkus.log.level=INFO
 quarkus.log.console.enable=true
 quarkus.log.console.level=WARNING
-quarkus.log.json.console.enable=true
+quarkus.log.json.console.enabled=true
 quarkus.log.json.log-format=ecs
 quarkus.log.json.fields.arguments.include-non-structured-arguments=true
 quarkus.log.json.additional-field."service.name".value=deployment-test

--- a/deployment/src/test/resources/application-json.properties
+++ b/deployment/src/test/resources/application-json.properties
@@ -1,7 +1,7 @@
 quarkus.log.level=INFO
 quarkus.log.console.enable=true
 quarkus.log.console.level=WARNING
-quarkus.log.json.console.enable=true
+quarkus.log.json.console.enabled=true
 quarkus.log.json.fields.arguments.include-non-structured-arguments=true
 quarkus.log.json.additional-field.serviceName.value=deployment-test
-quarkus.log.json.file.enable=true
+quarkus.log.json.file.enabled=true

--- a/docs/modules/ROOT/pages/includes/quarkus-log-json.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-log-json.adoc
@@ -10,30 +10,30 @@ h|[[quarkus-log-json_configuration]]link:#quarkus-log-json_configuration[Configu
 h|Type
 h|Default
 
-a| [[quarkus-log-json_quarkus.log.json.console.enable]]`link:#quarkus-log-json_quarkus.log.json.console.enable[quarkus.log.json.console.enable]`
+a| [[quarkus-log-json_quarkus.log.json.console.enabled]]`link:#quarkus-log-json_quarkus.log.json.console.enabled[quarkus.log.json.console.enabled]`
 
 [.description]
 --
 Determine whether to enable the JSON console formatting extension, which disables "normal" console formatting.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_CONSOLE_ENABLE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_CONSOLE_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_LOG_JSON_CONSOLE_ENABLE+++`
+Environment variable: `+++QUARKUS_LOG_JSON_CONSOLE_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
 
 
-a| [[quarkus-log-json_quarkus.log.json.file.enable]]`link:#quarkus-log-json_quarkus.log.json.file.enable[quarkus.log.json.file.enable]`
+a| [[quarkus-log-json_quarkus.log.json.file.enabled]]`link:#quarkus-log-json_quarkus.log.json.file.enabled[quarkus.log.json.file.enabled]`
 
 [.description]
 --
 Determine whether to enable the JSON file formatting extension, which disables "normal" file formatting.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FILE_ENABLE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FILE_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_LOG_JSON_FILE_ENABLE+++`

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -73,9 +73,6 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
-                    <compilerArgs>
-                        <arg>-AlegacyConfigRoot=true</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/JsonFormatter.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/JsonFormatter.java
@@ -15,7 +15,7 @@ public class JsonFormatter extends ExtFormatter {
     public JsonFormatter(List<JsonProvider> providers, JsonFactory jsonFactory, Config config) {
         this.providers = providers;
         this.jsonFactory = jsonFactory;
-        this.recordDelimiter = config.recordDelimiter;
+        this.recordDelimiter = config.recordDelimiter();
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
@@ -23,12 +23,12 @@ public class LoggingJsonRecorder {
 
     public RuntimeValue<Optional<Formatter>> initializeConsoleJsonLogging(Config config,
             JsonFactory jsonFactory) {
-        return initializeJsonLogging(config.console, config, jsonFactory);
+        return initializeJsonLogging(config.console(), config, jsonFactory);
     }
 
     public RuntimeValue<Optional<Formatter>> initializeFileJsonLogging(Config config,
             JsonFactory jsonFactory) {
-        return initializeJsonLogging(config.file, config, jsonFactory);
+        return initializeJsonLogging(config.file(), config, jsonFactory);
     }
 
     public RuntimeValue<Optional<Formatter>> initializeJsonLogging(ConfigFormatter formatter, Config config,
@@ -39,7 +39,7 @@ public class LoggingJsonRecorder {
 
         List<JsonProvider> providers;
 
-        if (config.logFormat == Config.LogFormat.ECS) {
+        if (config.logFormat() == Config.LogFormat.ECS) {
             providers = ecsFormat(config);
         } else {
             providers = defaultFormat(config);
@@ -68,42 +68,42 @@ public class LoggingJsonRecorder {
 
     private List<JsonProvider> defaultFormat(Config config) {
         List<JsonProvider> providers = new ArrayList<>();
-        providers.add(new TimestampJsonProvider(config.fields.timestamp));
-        providers.add(new SequenceJsonProvider(config.fields.sequence));
-        providers.add(new LoggerClassNameJsonProvider(config.fields.loggerClassName));
-        providers.add(new LoggerNameJsonProvider(config.fields.loggerName));
-        providers.add(new LogLevelJsonProvider(config.fields.level));
-        providers.add(new MessageJsonProvider(config.fields.message));
-        providers.add(new ThreadNameJsonProvider(config.fields.threadName));
-        providers.add(new ThreadIdJsonProvider(config.fields.threadId));
-        providers.add(new MDCJsonProvider(config.fields.mdc));
-        providers.add(new NDCJsonProvider(config.fields.ndc));
-        providers.add(new HostNameJsonProvider(config.fields.hostname));
-        providers.add(new ProcessNameJsonProvider(config.fields.processName));
-        providers.add(new ProcessIdJsonProvider(config.fields.processId));
-        providers.add(new StackTraceJsonProvider(config.fields.stackTrace));
-        providers.add(new ErrorTypeJsonProvider(config.fields.errorType));
-        providers.add(new ErrorMessageJsonProvider(config.fields.errorMessage));
-        providers.add(new ArgumentsJsonProvider(config.fields.arguments));
-        providers.add(new AdditionalFieldsJsonProvider(config.additionalField));
+        providers.add(new TimestampJsonProvider(config.fields().timestamp()));
+        providers.add(new SequenceJsonProvider(config.fields().sequence()));
+        providers.add(new LoggerClassNameJsonProvider(config.fields().loggerClassName()));
+        providers.add(new LoggerNameJsonProvider(config.fields().loggerName()));
+        providers.add(new LogLevelJsonProvider(config.fields().level()));
+        providers.add(new MessageJsonProvider(config.fields().message()));
+        providers.add(new ThreadNameJsonProvider(config.fields().threadName()));
+        providers.add(new ThreadIdJsonProvider(config.fields().threadId()));
+        providers.add(new MDCJsonProvider(config.fields().mdc()));
+        providers.add(new NDCJsonProvider(config.fields().ndc()));
+        providers.add(new HostNameJsonProvider(config.fields().hostname()));
+        providers.add(new ProcessNameJsonProvider(config.fields().processName()));
+        providers.add(new ProcessIdJsonProvider(config.fields().processId()));
+        providers.add(new StackTraceJsonProvider(config.fields().stackTrace()));
+        providers.add(new ErrorTypeJsonProvider(config.fields().errorType()));
+        providers.add(new ErrorMessageJsonProvider(config.fields().errorMessage()));
+        providers.add(new ArgumentsJsonProvider(config.fields().arguments()));
+        providers.add(new AdditionalFieldsJsonProvider(config.additionalField()));
         return providers;
     }
 
     private List<JsonProvider> ecsFormat(Config config) {
         List<JsonProvider> providers = new ArrayList<>();
-        providers.add(new TimestampJsonProvider(config.fields.timestamp, "@timestamp"));
-        providers.add(new LoggerNameJsonProvider(config.fields.loggerName, "log.logger"));
-        providers.add(new LogLevelJsonProvider(config.fields.level, "log.level"));
-        providers.add(new ThreadNameJsonProvider(config.fields.threadName, "process.thread.name"));
-        providers.add(new ThreadIdJsonProvider(config.fields.threadId, "process.thread.id"));
-        providers.add(new MDCJsonProvider(config.fields.mdc));
-        providers.add(new HostNameJsonProvider(config.fields.hostname, "host.name"));
-        providers.add(new StackTraceJsonProvider(config.fields.stackTrace, "error.stack_trace"));
-        providers.add(new ErrorTypeJsonProvider(config.fields.errorType, "error.type"));
-        providers.add(new ErrorMessageJsonProvider(config.fields.errorMessage, "error.message"));
-        providers.add(new ArgumentsJsonProvider(config.fields.arguments));
-        providers.add(new AdditionalFieldsJsonProvider(config.additionalField));
-        providers.add(new MessageJsonProvider(config.fields.message));
+        providers.add(new TimestampJsonProvider(config.fields().timestamp(), "@timestamp"));
+        providers.add(new LoggerNameJsonProvider(config.fields().loggerName(), "log.logger"));
+        providers.add(new LogLevelJsonProvider(config.fields().level(), "log.level"));
+        providers.add(new ThreadNameJsonProvider(config.fields().threadName(), "process.thread.name"));
+        providers.add(new ThreadIdJsonProvider(config.fields().threadId(), "process.thread.id"));
+        providers.add(new MDCJsonProvider(config.fields().mdc()));
+        providers.add(new HostNameJsonProvider(config.fields().hostname(), "host.name"));
+        providers.add(new StackTraceJsonProvider(config.fields().stackTrace(), "error.stack_trace"));
+        providers.add(new ErrorTypeJsonProvider(config.fields().errorType(), "error.type"));
+        providers.add(new ErrorMessageJsonProvider(config.fields().errorMessage(), "error.message"));
+        providers.add(new ArgumentsJsonProvider(config.fields().arguments()));
+        providers.add(new AdditionalFieldsJsonProvider(config.additionalField()));
+        providers.add(new MessageJsonProvider(config.fields().message()));
         providers.add(new StaticKeyValueProvider("ecs.version", "1.12.1"));
         return providers;
     }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/Config.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/Config.java
@@ -5,241 +5,252 @@ import java.util.Optional;
 
 import io.quarkiverse.loggingjson.providers.ArgumentsJsonProvider;
 import io.quarkiverse.loggingjson.providers.StructuredArgument;
-import io.quarkus.runtime.annotations.*;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
-@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "log.json")
-public class Config {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.log.json")
+public interface Config {
     /**
      * Configuration properties for console formatter.
      */
-    @ConfigItem(name = "console")
-    public ConfigConsole console;
+    @WithName("console")
+    ConfigConsole console();
 
     /**
      * Configuration properties for file formatter.
      */
-    @ConfigItem(name = "file")
-    public ConfigFile file;
+    @WithName("file")
+    ConfigFile file();
 
     /**
      * Configuration properties to customize fields
      */
-    @ConfigItem
-    public FieldsConfig fields;
+    FieldsConfig fields();
+
     /**
      * Enable "pretty printing" of the JSON record. Note that some JSON parsers will fail to read pretty printed output.
      */
-    @ConfigItem
-    public boolean prettyPrint;
+    @WithDefault("false")
+    boolean prettyPrint();
+
     /**
      * The special end-of-record delimiter to be used. By default, newline delimiter is used.
      */
-    @ConfigItem(defaultValue = "\n")
-    public String recordDelimiter;
+    @WithDefault("\n")
+    String recordDelimiter();
+
     /**
      * For adding fields to the json output directly from the config.
      */
-    @ConfigItem
     @ConfigDocMapKey("field-name")
     @ConfigDocSection
-    public Map<String, AdditionalFieldConfig> additionalField;
+    Map<String, AdditionalFieldConfig> additionalField();
 
     /**
      * Support changing logging format.
      */
-    @ConfigItem(defaultValue = "DEFAULT")
-    public LogFormat logFormat;
+    @WithDefault("DEFAULT")
+    LogFormat logFormat();
 
     @ConfigGroup
-    public static class FieldsConfig {
+    interface FieldsConfig {
         /**
          * Used to customize {@link ArgumentsJsonProvider}
          */
-        @ConfigItem
-        public ArgumentsConfig arguments;
+        ArgumentsConfig arguments();
+
         /**
          * Options for timestamp.
          */
-        @ConfigItem
-        public TimestampField timestamp;
+        TimestampField timestamp();
+
         /**
          * Options for hostname.
          */
-        @ConfigItem
-        public FieldConfig hostname;
+        FieldConfig hostname();
+
         /**
          * Options for sequence.
          */
-        @ConfigItem
-        public FieldConfig sequence;
+        FieldConfig sequence();
+
         /**
          * Options for loggerClassName.
          */
-        @ConfigItem
-        public FieldConfig loggerClassName;
+        FieldConfig loggerClassName();
+
         /**
          * Options for loggerName.
          */
-        @ConfigItem
-        public FieldConfig loggerName;
+        FieldConfig loggerName();
+
         /**
          * Options for level.
          */
-        @ConfigItem
-        public FieldConfig level;
+        FieldConfig level();
+
         /**
          * Options for message.
          */
-        @ConfigItem
-        public FieldConfig message;
+
+        FieldConfig message();
+
         /**
          * Options for threadName.
          */
-        @ConfigItem
-        public FieldConfig threadName;
+        FieldConfig threadName();
+
         /**
          * Options for threadId.
          */
-        @ConfigItem
-        public FieldConfig threadId;
+        FieldConfig threadId();
+
         /**
          * Options for mdc.
          */
-        @ConfigItem
-        public MDCConfig mdc;
+        MDCConfig mdc();
+
         /**
          * Options for ndc.
          */
-        @ConfigItem
-        public FieldConfig ndc;
+        FieldConfig ndc();
+
         /**
          * Options for processName.
          */
-        @ConfigItem
-        public FieldConfig processName;
+        FieldConfig processName();
+
         /**
          * Options for processId.
          */
-        @ConfigItem
-        public FieldConfig processId;
+        FieldConfig processId();
+
         /**
          * Options for stackTrace.
          */
-        @ConfigItem
-        public FieldConfig stackTrace;
+        FieldConfig stackTrace();
+
         /**
          * Options for errorType.
          */
-        @ConfigItem
-        public FieldConfig errorType;
+        FieldConfig errorType();
+
         /**
          * Options for errorMessage.
          */
-        @ConfigItem
-        public FieldConfig errorMessage;
+        FieldConfig errorMessage();
     }
 
     @ConfigGroup
-    public static class FieldConfig {
+    interface FieldConfig {
         /**
          * Used to change the json key for the field.
          */
-        @ConfigItem
-        public Optional<String> fieldName;
+        Optional<String> fieldName();
+
         /**
          * Enable or disable the field.
          */
-        @ConfigItem
-        public Optional<Boolean> enabled;
+        Optional<Boolean> enabled();
     }
 
     @ConfigGroup
-    public static class MDCConfig {
+    interface MDCConfig {
         /**
          * Used to change the json key for the field.
          */
-        @ConfigItem
-        public Optional<String> fieldName;
+        Optional<String> fieldName();
+
         /**
          * Enable or disable the field.
          */
-        @ConfigItem
-        public Optional<Boolean> enabled;
+        Optional<Boolean> enabled();
+
         /**
          * Will write the values at the top level of the JSON log object.
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean flatFields;
+        @WithDefault("false")
+        boolean flatFields();
     }
 
     @ConfigGroup
-    public static class TimestampField {
+    interface TimestampField {
         /**
          * Used to change the json key for the field.
          */
-        @ConfigItem
-        public Optional<String> fieldName;
+        Optional<String> fieldName();
+
         /**
          * The date format to use. The special string "default" indicates that the default format should be used.
          */
-        @ConfigItem(defaultValue = "default")
-        public String dateFormat;
+        @WithDefault("default")
+        String dateFormat();
+
         /**
          * The zone to use when formatting the timestamp.
          */
-        @ConfigItem(defaultValue = "default")
-        public String zoneId;
+        @WithDefault("default")
+        String zoneId();
+
         /**
          * Enable or disable the field.
          */
-        @ConfigItem
-        public Optional<Boolean> enabled;
+        Optional<Boolean> enabled();
     }
 
     @ConfigGroup
-    public static class ArgumentsConfig {
+    interface ArgumentsConfig {
 
         /**
-         * Used to wrap arguments in an json object, with this fieldName on root json.
+         * Used to wrap arguments in a json object, with this fieldName on root json.
          */
-        @ConfigItem
-        public Optional<String> fieldName = Optional.empty();
+        Optional<String> fieldName();
+
         /**
          * Enable output of structured logging arguments
          * {@link StructuredArgument},
          * default is true.
          */
-        @ConfigItem(defaultValue = "true")
-        public boolean includeStructuredArguments;
+        @WithDefault("true")
+        boolean includeStructuredArguments();
+
         /**
-         * Enable output of non structured logging arguments, default is false.
+         * Enable output of non-structured logging arguments, default is false.
          */
-        @ConfigItem(defaultValue = "false")
-        public boolean includeNonStructuredArguments;
+        @WithDefault("false")
+        boolean includeNonStructuredArguments();
+
         /**
-         * What prefix to use, when outputting non structured arguments. Default is `arg`, example key for first argument will
-         * be `arg0`.
+         * What prefixes to use, when outputting non-structured arguments.
+         * Default is `arg`, example key for the first argument will be `arg0`.
          */
-        @ConfigItem(defaultValue = "arg")
-        public String nonStructuredArgumentsFieldPrefix;
+        @WithDefault("arg")
+        String nonStructuredArgumentsFieldPrefix();
     }
 
     @ConfigGroup
-    public static class AdditionalFieldConfig {
+    interface AdditionalFieldConfig {
         /**
          * Additional field value.
          */
-        @ConfigItem
-        public String value;
+        String value();
+
         /**
          * Type of the field, default is STRING.
          * Supported types: STRING, INT, LONG, FLOAT, DOUBLE.
          */
-        @ConfigItem(defaultValue = "STRING")
-        public AdditionalFieldType type;
+        @WithDefault("STRING")
+        AdditionalFieldType type();
     }
 
-    public enum AdditionalFieldType {
+    enum AdditionalFieldType {
         STRING,
         INT,
         LONG,
@@ -247,7 +258,7 @@ public class Config {
         DOUBLE
     }
 
-    public enum LogFormat {
+    enum LogFormat {
         DEFAULT,
         ECS
     }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigConsole.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigConsole.java
@@ -1,18 +1,17 @@
 package io.quarkiverse.loggingjson.config;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
-public class ConfigConsole implements ConfigFormatter {
+public interface ConfigConsole extends ConfigFormatter {
     /**
      * Determine whether to enable the JSON console formatting extension, which disables "normal" console formatting.
      */
-    @ConfigItem(defaultValue = "true")
-    boolean enable;
+    @WithDefault("true")
+    boolean enabled();
 
-    @Override
-    public boolean isEnabled() {
-        return enable;
+    default boolean isEnabled() {
+        return enabled();
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigFile.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigFile.java
@@ -1,18 +1,17 @@
 package io.quarkiverse.loggingjson.config;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
-public class ConfigFile implements ConfigFormatter {
+public interface ConfigFile extends ConfigFormatter {
     /**
      * Determine whether to enable the JSON file formatting extension, which disables "normal" file formatting.
      */
-    @ConfigItem(defaultValue = "false")
-    boolean enable;
+    @WithDefault("false")
+    boolean enabled();
 
-    @Override
-    public boolean isEnabled() {
-        return enable;
+    default boolean isEnabled() {
+        return enabled();
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigFormatter.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/ConfigFormatter.java
@@ -1,6 +1,16 @@
 package io.quarkiverse.loggingjson.config;
 
+import io.smallrye.config.WithDefault;
+
 public interface ConfigFormatter {
 
-    boolean isEnabled();
+    /**
+     * Determine whether the formatter is enabled.
+     *
+     * @return true if the formatter is enabled, false otherwise
+     */
+    @WithDefault("false")
+    default boolean isEnabled() {
+        return false;
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/LoggingConfigFallbackConfigSourceInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/LoggingConfigFallbackConfigSourceInterceptor.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.loggingjson.config;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import io.smallrye.config.FallbackConfigSourceInterceptor;
+
+/**
+ * @deprecated maps the old config to the new config, should be removed at some point
+ */
+@Deprecated(forRemoval = true, since = "3.2.0")
+public class LoggingConfigFallbackConfigSourceInterceptor extends FallbackConfigSourceInterceptor {
+
+    private static final Map<String, String> FALLBACKS = LoggingConfigRelocateConfigSourceInterceptor.RELOCATIONS.entrySet()
+            .stream().collect(Collectors.toUnmodifiableMap(Entry::getValue, Entry::getKey));
+
+    public LoggingConfigFallbackConfigSourceInterceptor() {
+        super(FALLBACKS);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/LoggingConfigRelocateConfigSourceInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/LoggingConfigRelocateConfigSourceInterceptor.java
@@ -1,40 +1,17 @@
 package io.quarkiverse.loggingjson.config;
 
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 
-import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.RelocateConfigSourceInterceptor;
 
+@Deprecated(forRemoval = true, since = "3.2.0")
 public class LoggingConfigRelocateConfigSourceInterceptor extends RelocateConfigSourceInterceptor {
 
-    private static final Map<String, String> RELOCATIONS = relocations();
+    static final Map<String, String> RELOCATIONS = Map.of(
+            "quarkus.log.json.console.enable", "quarkus.log.json.console.enabled",
+            "quarkus.log.json.file.enable", "quarkus.log.json.file.enabled");
 
     public LoggingConfigRelocateConfigSourceInterceptor() {
         super(RELOCATIONS);
     }
-
-    @Override
-    public Iterator<String> iterateNames(final ConfigSourceInterceptorContext context) {
-        final Set<String> names = new HashSet<>();
-        final Iterator<String> namesIterator = context.iterateNames();
-        while (namesIterator.hasNext()) {
-            final String name = namesIterator.next();
-            names.add(name);
-            final String mappedName = RELOCATIONS.get(name);
-            if (mappedName != null) {
-                names.add(mappedName);
-            }
-        }
-        return names.iterator();
-    }
-
-    private static Map<String, String> relocations() {
-        return Map.of(
-                "quarkus.log.console.json.enable", "quarkus.log.console.json.enabled",
-                "quarkus.log.file.json.enable", "quarkus.log.file.json.enabled");
-    }
-
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/LoggingConfigRelocateConfigSourceInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/LoggingConfigRelocateConfigSourceInterceptor.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.loggingjson.config;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.RelocateConfigSourceInterceptor;
+
+public class LoggingConfigRelocateConfigSourceInterceptor extends RelocateConfigSourceInterceptor {
+
+    private static final Map<String, String> RELOCATIONS = relocations();
+
+    public LoggingConfigRelocateConfigSourceInterceptor() {
+        super(RELOCATIONS);
+    }
+
+    @Override
+    public Iterator<String> iterateNames(final ConfigSourceInterceptorContext context) {
+        final Set<String> names = new HashSet<>();
+        final Iterator<String> namesIterator = context.iterateNames();
+        while (namesIterator.hasNext()) {
+            final String name = namesIterator.next();
+            names.add(name);
+            final String mappedName = RELOCATIONS.get(name);
+            if (mappedName != null) {
+                names.add(mappedName);
+            }
+        }
+        return names.iterator();
+    }
+
+    private static Map<String, String> relocations() {
+        return Map.of(
+                "quarkus.log.console.json.enable", "quarkus.log.console.json.enabled",
+                "quarkus.log.file.json.enable", "quarkus.log.file.json.enabled");
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/AdditionalFieldsJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/AdditionalFieldsJsonProvider.java
@@ -23,8 +23,8 @@ public class AdditionalFieldsJsonProvider implements JsonProvider, Enabled {
     public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
         for (Map.Entry<String, Config.AdditionalFieldConfig> entry : fields.entrySet()) {
             final String fieldName = entry.getKey();
-            final String fieldValue = entry.getValue().value;
-            switch (entry.getValue().type) {
+            final String fieldValue = entry.getValue().value();
+            switch (entry.getValue().type()) {
                 case STRING:
                     generator.writeStringField(fieldName, fieldValue);
                     break;

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ArgumentsJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ArgumentsJsonProvider.java
@@ -17,10 +17,10 @@ public class ArgumentsJsonProvider implements JsonProvider, Enabled {
     private final Optional<String> fieldName;
 
     public ArgumentsJsonProvider(Config.ArgumentsConfig config) {
-        this.fieldName = config.fieldName;
-        this.includeStructuredArguments = config.includeStructuredArguments;
-        this.includeNonStructuredArguments = config.includeNonStructuredArguments;
-        this.nonStructuredArgumentsFieldPrefix = config.nonStructuredArgumentsFieldPrefix;
+        this.fieldName = config.fieldName();
+        this.includeStructuredArguments = config.includeStructuredArguments();
+        this.includeNonStructuredArguments = config.includeNonStructuredArguments();
+        this.nonStructuredArgumentsFieldPrefix = config.nonStructuredArgumentsFieldPrefix();
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ErrorMessageJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ErrorMessageJsonProvider.java
@@ -18,7 +18,7 @@ public class ErrorMessageJsonProvider implements JsonProvider, Enabled {
 
     public ErrorMessageJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -30,6 +30,6 @@ public class ErrorMessageJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ErrorTypeJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ErrorTypeJsonProvider.java
@@ -18,7 +18,7 @@ public class ErrorTypeJsonProvider implements JsonProvider, Enabled {
 
     public ErrorTypeJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -30,6 +30,6 @@ public class ErrorTypeJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/HostNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/HostNameJsonProvider.java
@@ -18,7 +18,7 @@ public class HostNameJsonProvider implements JsonProvider, Enabled {
 
     public HostNameJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -30,6 +30,6 @@ public class HostNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LogLevelJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LogLevelJsonProvider.java
@@ -17,7 +17,7 @@ public class LogLevelJsonProvider implements JsonProvider, Enabled {
 
     public LogLevelJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -27,6 +27,6 @@ public class LogLevelJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LoggerClassNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LoggerClassNameJsonProvider.java
@@ -17,7 +17,7 @@ public class LoggerClassNameJsonProvider implements JsonProvider, Enabled {
 
     public LoggerClassNameJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("loggerClassName");
+        this.fieldName = config.fieldName().orElse("loggerClassName");
     }
 
     @Override
@@ -27,6 +27,6 @@ public class LoggerClassNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LoggerNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/LoggerNameJsonProvider.java
@@ -17,7 +17,7 @@ public class LoggerNameJsonProvider implements JsonProvider, Enabled {
     }
 
     public LoggerNameJsonProvider(Config.FieldConfig config, String defaultName) {
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
         this.config = config;
     }
 
@@ -28,6 +28,6 @@ public class LoggerNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MDCJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MDCJsonProvider.java
@@ -17,10 +17,10 @@ public class MDCJsonProvider implements JsonProvider, Enabled {
 
     public MDCJsonProvider(Config.MDCConfig config) {
         this.config = config;
-        if (config.flatFields) {
+        if (config.flatFields()) {
             this.fieldName = null;
         } else {
-            this.fieldName = config.fieldName.orElse("mdc");
+            this.fieldName = config.fieldName().orElse("mdc");
         }
     }
 
@@ -31,6 +31,6 @@ public class MDCJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MessageJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MessageJsonProvider.java
@@ -18,7 +18,7 @@ public class MessageJsonProvider extends ExtFormatter implements JsonProvider, E
 
     public MessageJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("message");
+        this.fieldName = config.fieldName().orElse("message");
     }
 
     @Override
@@ -33,6 +33,6 @@ public class MessageJsonProvider extends ExtFormatter implements JsonProvider, E
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/NDCJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/NDCJsonProvider.java
@@ -17,7 +17,7 @@ public class NDCJsonProvider implements JsonProvider, Enabled {
 
     public NDCJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("ndc");
+        this.fieldName = config.fieldName().orElse("ndc");
     }
 
     @Override
@@ -29,6 +29,6 @@ public class NDCJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ProcessIdJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ProcessIdJsonProvider.java
@@ -17,7 +17,7 @@ public class ProcessIdJsonProvider implements JsonProvider, Enabled {
 
     public ProcessIdJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("processId");
+        this.fieldName = config.fieldName().orElse("processId");
     }
 
     @Override
@@ -29,6 +29,6 @@ public class ProcessIdJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ProcessNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ProcessNameJsonProvider.java
@@ -17,7 +17,7 @@ public class ProcessNameJsonProvider implements JsonProvider, Enabled {
 
     public ProcessNameJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("processName");
+        this.fieldName = config.fieldName().orElse("processName");
     }
 
     @Override
@@ -29,6 +29,6 @@ public class ProcessNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SequenceJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/SequenceJsonProvider.java
@@ -17,7 +17,7 @@ public class SequenceJsonProvider implements JsonProvider, Enabled {
 
     public SequenceJsonProvider(Config.FieldConfig config) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse("sequence");
+        this.fieldName = config.fieldName().orElse("sequence");
     }
 
     @Override
@@ -27,6 +27,6 @@ public class SequenceJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/StackTraceJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/StackTraceJsonProvider.java
@@ -19,7 +19,7 @@ public class StackTraceJsonProvider implements JsonProvider, Enabled {
 
     public StackTraceJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -33,6 +33,6 @@ public class StackTraceJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ThreadIdJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ThreadIdJsonProvider.java
@@ -21,7 +21,7 @@ public class ThreadIdJsonProvider implements JsonProvider, Enabled {
 
     public ThreadIdJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -31,6 +31,6 @@ public class ThreadIdJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ThreadNameJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/ThreadNameJsonProvider.java
@@ -21,7 +21,7 @@ public class ThreadNameJsonProvider implements JsonProvider, Enabled {
 
     public ThreadNameJsonProvider(Config.FieldConfig config, String defaultName) {
         this.config = config;
-        this.fieldName = config.fieldName.orElse(defaultName);
+        this.fieldName = config.fieldName().orElse(defaultName);
     }
 
     @Override
@@ -31,6 +31,6 @@ public class ThreadNameJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/TimestampJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/TimestampJsonProvider.java
@@ -25,17 +25,17 @@ public class TimestampJsonProvider implements JsonProvider, Enabled {
 
     public TimestampJsonProvider(Config.TimestampField config, String defaultName) {
         this.config = config;
-        fieldName = config.fieldName.orElse(defaultName);
+        fieldName = config.fieldName().orElse(defaultName);
 
         ZoneId zoneId;
-        if (config.zoneId == null || "default".equals(config.zoneId)) {
+        if (config.zoneId() == null || "default".equals(config.zoneId())) {
             zoneId = ZoneId.systemDefault();
         } else {
-            zoneId = ZoneId.of(config.zoneId);
+            zoneId = ZoneId.of(config.zoneId());
         }
 
-        if (config.dateFormat != null && !config.dateFormat.equals("default")) {
-            dateTimeFormatter = DateTimeFormatter.ofPattern(config.dateFormat).withZone(zoneId);
+        if (config.dateFormat() != null && !config.dateFormat().equals("default")) {
+            dateTimeFormatter = DateTimeFormatter.ofPattern(config.dateFormat()).withZone(zoneId);
         } else {
             dateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId);
         }
@@ -50,6 +50,6 @@ public class TimestampJsonProvider implements JsonProvider, Enabled {
 
     @Override
     public boolean isEnabled() {
-        return config.enabled.orElse(true);
+        return config.enabled().orElse(true);
     }
 }

--- a/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,1 +1,2 @@
 io.quarkiverse.loggingjson.config.LoggingConfigRelocateConfigSourceInterceptor
+io.quarkiverse.loggingjson.config.LoggingConfigFallbackConfigSourceInterceptor

--- a/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/runtime/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,0 +1,1 @@
+io.quarkiverse.loggingjson.config.LoggingConfigRelocateConfigSourceInterceptor

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/AdditionalFieldsJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/AdditionalFieldsJsonProviderJsonbTest.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
 import io.quarkiverse.loggingjson.config.Config;
+import io.quarkiverse.loggingjson.config.Config.AdditionalFieldConfig;
+import io.quarkiverse.loggingjson.config.Config.AdditionalFieldType;
 
 public class AdditionalFieldsJsonProviderJsonbTest extends JsonProviderBaseTest {
     @Override
@@ -59,9 +61,17 @@ public class AdditionalFieldsJsonProviderJsonbTest extends JsonProviderBaseTest 
     }
 
     private Config.AdditionalFieldConfig additionalFieldConfig(String value, Config.AdditionalFieldType type) {
-        final Config.AdditionalFieldConfig config = new Config.AdditionalFieldConfig();
-        config.value = value;
-        config.type = type;
-        return config;
+        return new AdditionalFieldConfig() {
+            @Override
+            public String value() {
+                return value;
+            }
+
+            @Override
+            public AdditionalFieldType type() {
+                return type;
+            }
+        };
+
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ArgumentsJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ArgumentsJsonProviderJsonbTest.java
@@ -22,11 +22,28 @@ public class ArgumentsJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.ArgumentsConfig config = new Config.ArgumentsConfig();
-        config.fieldName = Optional.empty();
-        config.includeStructuredArguments = true;
-        config.includeNonStructuredArguments = false;
-        config.nonStructuredArgumentsFieldPrefix = "arg";
+        final Config.ArgumentsConfig config = new Config.ArgumentsConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean includeStructuredArguments() {
+                return true;
+            }
+
+            @Override
+            public String nonStructuredArgumentsFieldPrefix() {
+                return "arg";
+            }
+
+            @Override
+            public boolean includeNonStructuredArguments() {
+                return false;
+            }
+        };
         final ArgumentsJsonProvider provider = new ArgumentsJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -50,11 +67,28 @@ public class ArgumentsJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfigShortCircuit() throws Exception {
-        final Config.ArgumentsConfig config = new Config.ArgumentsConfig();
-        config.fieldName = Optional.empty();
-        config.includeStructuredArguments = false;
-        config.includeNonStructuredArguments = false;
-        config.nonStructuredArgumentsFieldPrefix = "arg";
+        final Config.ArgumentsConfig config = new Config.ArgumentsConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean includeStructuredArguments() {
+                return false;
+            }
+
+            @Override
+            public String nonStructuredArgumentsFieldPrefix() {
+                return "arg";
+            }
+
+            @Override
+            public boolean includeNonStructuredArguments() {
+                return false;
+            }
+        };
         final ArgumentsJsonProvider provider = new ArgumentsJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -70,11 +104,27 @@ public class ArgumentsJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfigWrapInObject() throws Exception {
-        final Config.ArgumentsConfig config = new Config.ArgumentsConfig();
-        config.fieldName = Optional.of("arguments");
-        config.includeStructuredArguments = true;
-        config.includeNonStructuredArguments = true;
-        config.nonStructuredArgumentsFieldPrefix = "arg";
+        final Config.ArgumentsConfig config = new Config.ArgumentsConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("arguments");
+            }
+
+            @Override
+            public boolean includeStructuredArguments() {
+                return true;
+            }
+
+            @Override
+            public String nonStructuredArgumentsFieldPrefix() {
+                return "arg";
+            }
+
+            @Override
+            public boolean includeNonStructuredArguments() {
+                return true;
+            }
+        };
         final ArgumentsJsonProvider provider = new ArgumentsJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ErrorMessageJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ErrorMessageJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class ErrorMessageJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ErrorMessageJsonProvider provider = new ErrorMessageJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing errorMessage");
@@ -39,9 +47,19 @@ public class ErrorMessageJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("em");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("em");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final ErrorMessageJsonProvider provider = new ErrorMessageJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing errorMessage");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ErrorTypeJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ErrorTypeJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class ErrorTypeJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ErrorTypeJsonProvider provider = new ErrorTypeJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing errorType");
@@ -39,9 +47,19 @@ public class ErrorTypeJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("et");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("et");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final ErrorTypeJsonProvider provider = new ErrorTypeJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing errorType");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/HostNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/HostNameJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class HostNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final HostNameJsonProvider provider = new HostNameJsonProvider(config);
 
         final JsonNode result = getResultAsJsonNode(provider, new ExtLogRecord(Level.ALL, "", ""));
@@ -34,9 +42,19 @@ public class HostNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("host");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("host");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final HostNameJsonProvider provider = new HostNameJsonProvider(config);
 
         final JsonNode result = getResultAsJsonNode(provider, new ExtLogRecord(Level.ALL, "", ""));

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LogLevelJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LogLevelJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class LogLevelJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final LogLevelJsonProvider provider = new LogLevelJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -36,9 +44,19 @@ public class LogLevelJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("logLevel");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("logLevel");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final LogLevelJsonProvider provider = new LogLevelJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LoggerClassNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LoggerClassNameJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class LoggerClassNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final LoggerClassNameJsonProvider provider = new LoggerClassNameJsonProvider(config);
 
         final JsonNode result = getResultAsJsonNode(provider,
@@ -36,9 +44,19 @@ public class LoggerClassNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("loggerClass");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("loggerClass");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final LoggerClassNameJsonProvider provider = new LoggerClassNameJsonProvider(config);
 
         final JsonNode result = getResultAsJsonNode(provider,

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LoggerNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/LoggerNameJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class LoggerNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final LoggerNameJsonProvider provider = new LoggerNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -37,9 +45,19 @@ public class LoggerNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("logger");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("logger");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final LoggerNameJsonProvider provider = new LoggerNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MDCJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MDCJsonProviderJsonbTest.java
@@ -21,9 +21,22 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.MDCConfig config = new Config.MDCConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.MDCConfig config = new Config.MDCConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean flatFields() {
+                return false;
+            }
+        };
         final MDCJsonProvider provider = new MDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -42,9 +55,25 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.MDCConfig config = new Config.MDCConfig();
-        config.fieldName = Optional.of("m");
-        config.enabled = Optional.of(false);
+        final var config = new Config.MDCConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("m");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+
+            @Override
+            public boolean flatFields() {
+                return false;
+            }
+        };
+
         final MDCJsonProvider provider = new MDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -67,10 +96,23 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testFlatCustomConfig() throws Exception {
-        final Config.MDCConfig config = new Config.MDCConfig();
-        config.fieldName = Optional.of("m");
-        config.enabled = Optional.empty();
-        config.flatFields = true;
+        final Config.MDCConfig config = new Config.MDCConfig() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("m");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean flatFields() {
+                return true;
+            }
+        };
         final MDCJsonProvider provider = new MDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MessageJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MessageJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class MessageJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final MessageJsonProvider provider = new MessageJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "TestMessage {0}", "");
@@ -38,9 +46,19 @@ public class MessageJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("msg");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("msg");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final MessageJsonProvider provider = new MessageJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "TestMessage {0}", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/NDCJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/NDCJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class NDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final NDCJsonProvider provider = new NDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -37,9 +45,19 @@ public class NDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("n");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("n");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final NDCJsonProvider provider = new NDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ProcessIdJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ProcessIdJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class ProcessIdJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ProcessIdJsonProvider provider = new ProcessIdJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -35,9 +43,19 @@ public class ProcessIdJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("pid");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("pid");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final ProcessIdJsonProvider provider = new ProcessIdJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ProcessNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ProcessNameJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class ProcessNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ProcessNameJsonProvider provider = new ProcessNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -37,9 +45,19 @@ public class ProcessNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("pn");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("pn");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final ProcessNameJsonProvider provider = new ProcessNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SequenceJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/SequenceJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class SequenceJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final SequenceJsonProvider provider = new SequenceJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -35,9 +43,19 @@ public class SequenceJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("seq");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("seq");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final SequenceJsonProvider provider = new SequenceJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/StackTraceJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/StackTraceJsonProviderJsonbTest.java
@@ -21,9 +21,17 @@ public class StackTraceJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final StackTraceJsonProvider provider = new StackTraceJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing stackTrace");
@@ -44,9 +52,19 @@ public class StackTraceJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("st");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("st");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final StackTraceJsonProvider provider = new StackTraceJsonProvider(config);
 
         final RuntimeException t = new RuntimeException("Testing stackTrace");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ThreadIdJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ThreadIdJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class ThreadIdJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ThreadIdJsonProvider provider = new ThreadIdJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -35,9 +43,23 @@ public class ThreadIdJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("tid");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("tid");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+
+            public void setEnabled(Optional<Boolean> enabled) {
+                this.enabled = enabled;
+            }
+        };
         final ThreadIdJsonProvider provider = new ThreadIdJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -48,7 +70,7 @@ public class ThreadIdJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals(3249, tid);
         Assertions.assertFalse(provider.isEnabled());
 
-        config.enabled = Optional.of(true);
+        config.setEnabled(Optional.of(true));
         Assertions.assertTrue(new ThreadIdJsonProvider(config).isEnabled());
     }
 }

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ThreadNameJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/ThreadNameJsonProviderJsonbTest.java
@@ -19,9 +19,17 @@ public class ThreadNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final Config.FieldConfig config = new Config.FieldConfig() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final ThreadNameJsonProvider provider = new ThreadNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -37,9 +45,20 @@ public class ThreadNameJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
-        config.fieldName = Optional.of("tn");
-        config.enabled = Optional.of(false);
+        final var config = new Config.FieldConfig() {
+
+            private Optional<Boolean> enabled = Optional.of(false);
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("tn");
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final ThreadNameJsonProvider provider = new ThreadNameJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/TimestampJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/TimestampJsonProviderJsonbTest.java
@@ -25,10 +25,28 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.empty();
-        config.dateFormat = "default";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
 
         OffsetDateTime beforeLog = OffsetDateTime.now().minusSeconds(1);
@@ -44,10 +62,27 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.of("@timestamp");
-        config.dateFormat = "dd-MM-yyyy HH:mm:ss.SSS";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("@timestamp");
+            }
+
+            @Override
+            public String dateFormat() {
+                return "dd-MM-yyyy HH:mm:ss.SSS";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
 
         LocalDateTime beforeLog = LocalDateTime.now().minusSeconds(1);
@@ -63,9 +98,29 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfigDisabled() {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.empty();
-        config.enabled = Optional.empty();
+        final var config = new Config.TimestampField() {
+            private Optional<Boolean> enabled = Optional.empty();
+
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return enabled;
+            }
+        };
         final TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
         Assertions.assertTrue(timestampJsonProvider.isEnabled());
 
@@ -75,10 +130,27 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomDateFormatConfigFail() {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.of("@timestamp");
-        config.dateFormat = "sdkfjl";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("@timestamp");
+            }
+
+            @Override
+            public String dateFormat() {
+                return "sdkfjl";
+            }
+
+            @Override
+            public String zoneId() {
+                return "default";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
 
         try {
             new TimestampJsonProvider(config);
@@ -89,10 +161,27 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomZoneIdConfig() throws Exception {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.of("timestamp");
-        config.zoneId = "Antarctica/Davis";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("timestamp");
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "Antarctica/Davis";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
         final TimestampJsonProvider timestampJsonProvider = new TimestampJsonProvider(config);
 
         ZonedDateTime beforeLog = ZonedDateTime.now().minusSeconds(1).withZoneSameInstant(ZoneId.of("+7"));
@@ -109,10 +198,27 @@ public class TimestampJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomZoneIdConfigFail() {
-        final Config.TimestampField config = new Config.TimestampField();
-        config.fieldName = Optional.of("timestamp");
-        config.zoneId = "sdkfjl";
-        config.enabled = Optional.empty();
+        final Config.TimestampField config = new Config.TimestampField() {
+            @Override
+            public Optional<String> fieldName() {
+                return Optional.of("timestamp");
+            }
+
+            @Override
+            public String dateFormat() {
+                return "default";
+            }
+
+            @Override
+            public String zoneId() {
+                return "sdkfjl";
+            }
+
+            @Override
+            public Optional<Boolean> enabled() {
+                return Optional.empty();
+            }
+        };
 
         try {
             new TimestampJsonProvider(config);


### PR DESCRIPTION
@gsmet  and @SlyngDK 


Changes:

`quarkus.log.json.console.enable=false` to `quarkus.log.json.console.enabled=false`

Implemented a relocator for backwards compatibility as suggested by @acoburn 