### PR TITLE
Register the java time module for the jackson object mapper.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.19.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
             <classifier>runtime</classifier>

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/jackson/JacksonJsonFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/jackson/JacksonJsonFactory.java
@@ -5,6 +5,7 @@ import java.util.ServiceConfigurationError;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.quarkiverse.loggingjson.JsonFactory;
 import io.quarkiverse.loggingjson.JsonGenerator;
@@ -19,7 +20,8 @@ public class JacksonJsonFactory implements JsonFactory {
     }
 
     private com.fasterxml.jackson.core.JsonFactory createJsonFactory() {
-        ObjectMapper objectMapper = new ObjectMapper()
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModules(new JavaTimeModule())
                 /*
                  * Assume empty beans are ok.
                  */


### PR DESCRIPTION
Regarding https://github.com/quarkiverse/quarkus-logging-json/issues/305