### PR TITLE
Adds support for the "eventId" JSON provider.

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-logging-json_quarkus.log.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-logging-json_quarkus.log.adoc
@@ -238,6 +238,43 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
+a| [[quarkus-logging-json_quarkus-log-json-fields-event-id-field-name]] [.property-path]##link:#quarkus-logging-json_quarkus-log-json-fields-event-id-field-name[`quarkus.log.json.fields.event-id.field-name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.log.json.fields.event-id.field-name+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Used to change the json key for the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_EVENT_ID_FIELD_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_EVENT_ID_FIELD_NAME+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|`eventId` or `event.id` if `quarkus.log.json.log-format` is `ecs`
+
+a| [[quarkus-logging-json_quarkus-log-json-fields-event-id-enabled]] [.property-path]##link:#quarkus-logging-json_quarkus-log-json-fields-event-id-enabled[`quarkus.log.json.fields.event-id.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.log.json.fields.event-id.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable or disable the field.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_LOG_JSON_FIELDS_EVENT_ID_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_LOG_JSON_FIELDS_EVENT_ID_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|false
+
 a| [[quarkus-logging-json_quarkus-log-json-fields-hostname-field-name]] [.property-path]##link:#quarkus-logging-json_quarkus-log-json-fields-hostname-field-name[`quarkus.log.json.fields.hostname.field-name`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.log.json.fields.hostname.field-name+++[]

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/LoggingJsonRecorder.java
@@ -100,6 +100,8 @@ public class LoggingJsonRecorder {
     private List<JsonProvider> ecsFormat(Config config) {
         List<JsonProvider> providers = new ArrayList<>();
         providers.add(new TimestampJsonProvider(config.fields().timestamp(), "@timestamp"));
+        // @see <a href="https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-id"><abbr title="Elastic Common Schema">ECS</abbr> Field Reference - <code>event.id</code></a>
+        providers.add(new EventIdJsonProvider(config.fields().eventId(), "event.id"));
         providers.add(new LoggerNameJsonProvider(config.fields().loggerName(), "log.logger"));
         providers.add(new LogLevelJsonProvider(config.fields().level(), "log.level"));
         providers.add(new ThreadNameJsonProvider(config.fields().threadName(), "process.thread.name"));

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/config/Config.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/config/Config.java
@@ -78,6 +78,11 @@ public interface Config {
         TimestampField timestamp();
 
         /**
+         * Options for eventId.
+         */
+        EventIdField eventId();
+
+        /**
          * Options for hostname.
          */
         FieldConfig hostname();
@@ -209,6 +214,22 @@ public interface Config {
          * Enable or disable the field.
          */
         Optional<Boolean> enabled();
+    }
+
+    @ConfigGroup
+	interface EventIdField {
+        /**
+         * Used to change the json key for the field.
+         */
+		Optional<String> fieldName();
+
+        /**
+         * Enable or disable the field.
+         * <p>
+         * This field is disabled by default for performance consideration.
+         */
+		@WithDefault("false")
+        boolean enabled();
     }
 
     @ConfigGroup

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/EventIdJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/EventIdJsonProvider.java
@@ -1,0 +1,92 @@
+package io.quarkiverse.loggingjson.providers;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+import io.quarkiverse.loggingjson.Enabled;
+import io.quarkiverse.loggingjson.JsonGenerator;
+import io.quarkiverse.loggingjson.JsonProvider;
+import io.quarkiverse.loggingjson.JsonWritingUtils;
+import io.quarkiverse.loggingjson.config.Config;
+
+/**
+ * JsonProvider for the <code>event.id</code> field: Unique ID to describe the event.
+ *
+ * @see <a href="https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-id"><abbr
+ *      title="Elastic Common Schema">ECS</abbr> Field Reference - <code>event.id</code></a>
+ */
+public class EventIdJsonProvider implements JsonProvider, Enabled {
+    /**
+     * Base64 URL encoder without padding.
+     */
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    private final String fieldName;
+    private final Config.EventIdField config;
+    private final Supplier<UUID> uuidGenerator;
+
+    public EventIdJsonProvider(Config.EventIdField config) {
+        this(config, "eventId", UUID::randomUUID);
+    }
+
+    public EventIdJsonProvider(Config.EventIdField config, String defaultName) {
+        this(config, defaultName, UUID::randomUUID);
+    }
+
+    EventIdJsonProvider(Config.EventIdField config, String defaultName, Supplier<UUID> uuidGenerator) {
+        this.config = config;
+        this.fieldName = config.fieldName().orElse(defaultName);
+
+        this.uuidGenerator = uuidGenerator;
+    }
+
+    @Override
+    public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
+        JsonWritingUtils.writeStringField(generator, this.fieldName, generateEncodedUUID());
+    }
+
+    private String generateEncodedUUID() {
+        UUID uuid = this.uuidGenerator.get();
+        byte[] uuidBytes = asByteArray(uuid);
+        return encode(uuidBytes);
+    }
+
+    /**
+     * Converts a UUID to a byte array.
+     *
+     * @param uuid the UUID to convert
+     * @return the byte array representation of the UUID
+     */
+    private byte[] asByteArray(UUID uuid) {
+        byte[] bytes = new byte[16];
+        long mostSigBits = uuid.getMostSignificantBits();
+        long leastSigBits = uuid.getLeastSignificantBits();
+
+        for (int i = 0; i < 8; i++) {
+            bytes[i] = (byte) (mostSigBits >>> (8 * (7 - i)));
+        }
+        for (int i = 0; i < 8; i++) {
+            bytes[i + 8] = (byte) (leastSigBits >>> (8 * (7 - i)));
+        }
+        return bytes;
+    }
+
+    /**
+     * Encodes a byte array to a Base64 string.
+     *
+     * @param data the byte array to encode
+     * @return the Base64 encoded string
+     */
+    private String encode(byte[] data) {
+        return ENCODER.encodeToString(data);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return config.enabled();
+    }
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/EventIdJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/EventIdJsonProviderJsonbTest.java
@@ -1,0 +1,90 @@
+package io.quarkiverse.loggingjson.providers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkiverse.loggingjson.config.Config;
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Level;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class EventIdJsonProviderJsonbTest extends JsonProviderBaseTest {
+	@Override
+	protected Type type() {
+		return Type.JSONB;
+	}
+
+	@Test
+	void testDefaultConfig() throws Exception {
+		final Config.EventIdField config = new Config.EventIdField() {
+			@Override
+			public Optional<String> fieldName() {
+				return Optional.empty();
+			}
+
+			@Override
+			public boolean enabled() {
+				return false;
+			}
+		};
+		final EventIdJsonProvider provider = new EventIdJsonProvider(config);
+
+		final JsonNode result = getResultAsJsonNode(provider, new ExtLogRecord(Level.ALL, "", ""));
+
+		String eventId = result.findValue("eventId").asText();
+		Assertions.assertNotNull(eventId);
+	}
+
+	@Test
+	void testCustomConfig() throws IOException {
+		// Given
+		final String customFieldName = "customEventIdFieldName";
+		final Config.EventIdField config = new Config.EventIdField() {
+			@Override
+			public Optional<String> fieldName() {
+				return Optional.of(customFieldName);
+			}
+
+			@Override
+			public boolean enabled() {
+				return true;
+			}
+		};
+		final ExtLogRecord record = new ExtLogRecord(Level.ALL, "", "");
+
+		final UUID mockedUUID = UUID.fromString("201d870c-d9ee-4ed0-b209-620e017c2de9");
+		final String encodedMockedUUID = "IB2HDNnuTtCyCWIOAXwt6Q";
+
+		final EventIdJsonProvider eventIdJsonProvider = new EventIdJsonProvider(config, "eventId", () -> mockedUUID);
+
+		// When
+		final JsonNode result = getResultAsJsonNode(eventIdJsonProvider, record);
+
+		// Then
+		String eventId = result.findValue(customFieldName).asText();
+		assertEquals(encodedMockedUUID, eventId);
+	}
+
+	@Test
+	void testConfigEnabled() {
+		final Config.EventIdField config = new Config.EventIdField() {
+			@Override
+			public Optional<String> fieldName() {
+				return Optional.of("event.id");
+			}
+
+			@Override
+			public boolean enabled() {
+				return false;
+			}
+		};
+		final EventIdJsonProvider eventIdJsonProvider = new EventIdJsonProvider(config, "eventId");
+		assertFalse(eventIdJsonProvider.isEnabled());
+	}
+}

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/EventIdJsonProviderJacksonTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/jackson/EventIdJsonProviderJacksonTest.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.loggingjson.providers.jackson;
+
+import io.quarkiverse.loggingjson.providers.EventIdJsonProviderJsonbTest;
+
+public class EventIdJsonProviderJacksonTest extends EventIdJsonProviderJsonbTest {
+    @Override
+    protected Type type() {
+        return Type.JACKSON;
+    }
+}


### PR DESCRIPTION
This property can be very useful to avoid log duplication (such as when re-ingesting a rotated log file).

@SlyngDK: I have rebased works of https://github.com/quarkiverse/quarkus-logging-json/pull/349 on latest version of [quarkus-logging-json](https://github.com/quarkiverse/quarkus-logging-json) (version : 3.3.1)
